### PR TITLE
feat: 채팅을 db에 저장하는 로직 추가

### DIFF
--- a/src/main/java/com/example/earthtalk/domain/debate/component/WebSocketEventListener.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/component/WebSocketEventListener.java
@@ -6,15 +6,20 @@ import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionConnectedEvent;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.example.earthtalk.domain.debate.dto.DebateMessage;
 import com.example.earthtalk.domain.debate.dto.SessionInfo;
 import com.example.earthtalk.domain.debate.model.ChatRoom;
+import com.example.earthtalk.domain.debate.service.DebateChatService;
 import com.example.earthtalk.domain.debate.service.ChatRoomService;
 import com.example.earthtalk.domain.debate.service.DebateUserService;
-import com.example.earthtalk.global.exception.BadRequestException;
+import com.example.earthtalk.domain.debate.store.ChatMessageStore;
 import com.example.earthtalk.global.exception.ErrorCode;
+import com.example.earthtalk.global.exception.IllegalArgumentException;
 
 /**
  * WebSocketEventListener는 WebSocket 연결 및 연결 해제 이벤트를 처리하여
@@ -27,8 +32,11 @@ public class WebSocketEventListener {
 	private final DebateUserService debateUserService;
 	private final ChatRoomService chatRoomService;
 
+	private final DebateChatService debateChatService;
+
 	// 여러 개의 맵 대신 세션 ID와 관련된 정보를 하나의 객체(SessionInfo)로 관리
 	private final Map<String, SessionInfo> sessionInfoMap = new ConcurrentHashMap<>();
+	private final ChatMessageStore chatMessageStore;
 
 	/**
 	 * WebSocket 연결 이벤트를 처리하여 세션 정보를 저장하고, 해당 채팅방에 사용자를 추가합니다.
@@ -49,22 +57,40 @@ public class WebSocketEventListener {
 
 			ChatRoom chatRoom = chatRoomService.getChatRoom(roomId);
 			if (chatRoom == null) {
-				throw new BadRequestException(ErrorCode.BAD_REQUEST);
+				throw new IllegalArgumentException(ErrorCode.CHAT_NOT_FOUND);
 			}
 			debateUserService.addUser(chatRoom, userName, position);
 		}
 	}
 
 	/**
-	 * WebSocket 연결 해제 이벤트를 처리하여 세션 정보를 제거하고, 해당 사용자를 Debate 방에서 제거합니다.
+	 * WebSocket 연결 해제 이벤트를 처리합니다.
+	 * <p>
+	 * 사용자가 WebSocket에서 연결을 해제하면, 해당 세션 정보를 제거하고 사용자를 채팅방에서 삭제합니다.
+	 * 또한, 사용자가 속해 있던 채팅방의 채팅 메시지를 저장소에서 제거한 후, 영속 저장소(DB)에 저장합니다.
+	 * </p>
 	 *
-	 * @param event SessionDisconnectEvent 이벤트 객체
+	 * <h3>처리 과정:</h3>
+	 * <ol>
+	 *     <li>세션 정보를 조회하여 해당 사용자의 roomId를 가져옵니다.</li>
+	 *     <li>채팅 메시지 저장소({@link ChatMessageStore})에서 해당 roomId의 메시지를 가져옵니다.</li>
+	 *     <li>메시지가 존재하면 {@link DebateChatService#saveChatHistory(String, List)}를 호출하여 DB에 저장합니다.</li>
+	 *     <li>사용자를 {@link DebateUserService#removeUser(String, String)}를 통해 채팅방에서 제거합니다.</li>
+	 * </ol>
+	 *
+	 * @param event {@link SessionDisconnectEvent} - WebSocket 연결 해제 이벤트 객체
 	 */
 	@EventListener
 	public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
 		String sessionId = event.getSessionId();
 		SessionInfo sessionInfo = sessionInfoMap.remove(sessionId);
 		if (sessionInfo != null) {
+			String roomId = sessionInfo.getRoomId();
+
+			List<DebateMessage> messages = chatMessageStore.removeChatMessages(roomId);
+			if (messages != null && !messages.isEmpty()) {
+				debateChatService.saveChatHistory(roomId, messages);
+			}
 			debateUserService.removeUser(sessionInfo.getRoomId(), sessionInfo.getUserName());
 		}
 	}

--- a/src/main/java/com/example/earthtalk/domain/debate/dto/DebateMessage.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/dto/DebateMessage.java
@@ -1,5 +1,7 @@
 package com.example.earthtalk.domain.debate.dto;
 
+import java.time.LocalDateTime;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,8 +10,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class DebateMessage {
+
 	private String event;
+
 	private String userName;
+
 	private String position;
+
 	private String message;
+
+	private LocalDateTime time;
 }

--- a/src/main/java/com/example/earthtalk/domain/debate/dto/ObserverMessage.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/dto/ObserverMessage.java
@@ -9,9 +9,15 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ObserverMessage {
 	private String event;
-	private String roomId;
+
+	private String uuid;
+
 	private Long userId;
+
 	private String userName;
+
 	private String message;
+
 	private String timestamp;
+
 }

--- a/src/main/java/com/example/earthtalk/domain/debate/dto/SessionInfo.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/dto/SessionInfo.java
@@ -12,6 +12,9 @@ import lombok.ToString;
 @ToString
 public class SessionInfo {
 	private String roomId;
+
 	private String userName;
+
 	private String position;
+
 }

--- a/src/main/java/com/example/earthtalk/domain/debate/entity/Debate.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/entity/Debate.java
@@ -17,6 +17,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 import jakarta.persistence.PrePersist;
 import lombok.AccessLevel;
@@ -37,6 +38,9 @@ public class Debate extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false)
+    private UUID uuid;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "news_id")

--- a/src/main/java/com/example/earthtalk/domain/debate/entity/DebateChat.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/entity/DebateChat.java
@@ -1,5 +1,7 @@
 package com.example.earthtalk.domain.debate.entity;
 
+import java.time.LocalDateTime;
+
 import com.example.earthtalk.global.baseTime.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -33,5 +35,11 @@ public class DebateChat extends BaseTimeEntity {
     private DebateUser debateUser;
 
     @Column(nullable = false)
+    private FlagType flagType;
+
+    @Column(nullable = false)
     private String content;
+
+    @Column(nullable = false)
+    private LocalDateTime time;
 }

--- a/src/main/java/com/example/earthtalk/domain/debate/entity/DebateUser.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/entity/DebateUser.java
@@ -44,10 +44,20 @@ public class DebateUser extends BaseTimeEntity {
     @Column(nullable = false)
     private FlagType position;// 찬/반 여부
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private FlagType afterPosition;
+
     @PrePersist
     public void setDefaultPosition() {
         if (this.position == null) {
             this.position = FlagType.NO_POSITION;
         }
+
+        if (this.afterPosition == null) {
+            this.afterPosition = FlagType.NO_POSITION;
+        }
     }
+
+
 }

--- a/src/main/java/com/example/earthtalk/domain/debate/entity/FlagType.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/entity/FlagType.java
@@ -1,11 +1,27 @@
 package com.example.earthtalk.domain.debate.entity;
 
+import java.util.Arrays;
+
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public enum FlagType {
-    PRO,
-    CON,
-    NO_POSITION
+    PRO("pro"),
+    CON("con"),
+    NO_POSITION("noPosition");
 
+    private final String position;
+
+    public static FlagType fromString(String position) {
+        if (position == null) {
+            return null;
+        }
+
+        return Arrays.stream(FlagType.values())
+            .filter(flag -> flag.position.equalsIgnoreCase(position))
+            .findFirst()
+            .orElse(NO_POSITION);
+    }
 }

--- a/src/main/java/com/example/earthtalk/domain/debate/repository/DebateChatRepository.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/repository/DebateChatRepository.java
@@ -1,8 +1,11 @@
 package com.example.earthtalk.domain.debate.repository;
 
 
+import java.util.Optional;
+
 import com.example.earthtalk.domain.debate.entity.DebateChat;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DebateChatRepository extends JpaRepository<DebateChat, Long> {
+
 }

--- a/src/main/java/com/example/earthtalk/domain/debate/repository/DebateRepository.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/repository/DebateRepository.java
@@ -1,8 +1,12 @@
 package com.example.earthtalk.domain.debate.repository;
 
+import java.util.Optional;
+import java.util.UUID;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.example.earthtalk.domain.debate.entity.Debate;
 
 public interface DebateRepository extends JpaRepository<Debate, Long> {
+	Optional<Debate> findByUuid(UUID uuid);
 }

--- a/src/main/java/com/example/earthtalk/domain/debate/repository/DebateUserRepository.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/repository/DebateUserRepository.java
@@ -1,8 +1,11 @@
 package com.example.earthtalk.domain.debate.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.example.earthtalk.domain.debate.entity.DebateUser;
 
 public interface DebateUserRepository extends JpaRepository<DebateUser, Long> {
+	Optional<DebateUser> findByUser_Nickname(String username);
 }

--- a/src/main/java/com/example/earthtalk/domain/debate/service/DebateChatService.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/service/DebateChatService.java
@@ -1,0 +1,100 @@
+package com.example.earthtalk.domain.debate.service;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import com.example.earthtalk.domain.debate.dto.DebateMessage;
+import com.example.earthtalk.domain.debate.entity.Debate;
+import com.example.earthtalk.domain.debate.entity.DebateChat;
+import com.example.earthtalk.domain.debate.entity.DebateUser;
+import com.example.earthtalk.domain.debate.entity.FlagType;
+import com.example.earthtalk.domain.debate.repository.DebateChatRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * DebateChatService는 토론방의 채팅 메시지를 DebateChat 엔티티로 변환하여 데이터베이스에 저장하는 기능을 제공합니다.
+ * <p>
+ * 이 서비스는 DebateService를 통해 토론방(Debate) 정보를 조회하고, DebateUserService를 통해 사용자의 정보를 확인한 후,
+ * DebateMessage의 이벤트가 "chat"인 경우에만 해당 메시지를 DebateChat 엔티티로 매핑하여 DebateChatRepository를 통해 일괄 저장합니다.
+ * 만약 해당 메시지에 대응하는 DebateUser가 존재하지 않으면, 해당 메시지는 무시됩니다.
+ * </p>
+ */
+@Service
+@RequiredArgsConstructor
+public class DebateChatService {
+
+	private final DebateChatRepository debateChatRepository;
+	private final DebateUserService debateUserService;
+	private final DebateService debateService;
+
+	/**
+	 * 주어진 토론방(UUID)와 DebateMessage 리스트를 기반으로 채팅 로그를 데이터베이스에 저장합니다.
+	 * <p>
+	 * 처리 과정:
+	 * <ol>
+	 *   <li>주어진 uuid를 이용하여 Debate 엔티티를 조회합니다.</li>
+	 *   <li>DebateMessage 리스트를 스트림으로 순회하면서, 이벤트가 "chat"인 메시지에 대해 다음 작업을 수행합니다:
+	 *     <ul>
+	 *       <li>DebateUserService를 이용하여 해당 메시지의 userName에 해당하는 DebateUser 객체를 조회합니다.</li>
+	 *       <li>메시지의 position 값에 따라 FlagType을 결정합니다. ("pro" → {@link FlagType#PRO}, "con" → {@link FlagType#CON}, 그 외 → {@link FlagType#NO_POSITION})</li>
+	 *       <li>만약 DebateUser가 존재하지 않으면, 해당 메시지는 무시됩니다.</li>
+	 *       <li>DebateChat 엔티티를 Builder 패턴을 이용해 생성합니다.</li>
+	 *     </ul>
+	 *   </li>
+	 *   <li>생성된 DebateChat 엔티티들을 리스트로 수집한 후, DebateChatRepository를 통해 일괄 저장합니다.</li>
+	 * </ol>
+	 * </p>
+	 *
+	 * @param uuid     토론방을 식별하기 위한 UUID 문자열
+	 * @param messages 해당 토론방에서 발생한 DebateMessage 리스트
+	 */
+	@Async
+	public void saveChatHistory(String uuid, List<DebateMessage> messages) {
+		Debate debate = debateService.getDebateByRoomId(uuid);
+
+		List<DebateChat> chatList = messages.stream()
+			.map(message -> {
+				if (message.getEvent().equals("chat")) {
+					DebateUser debateUser = debateUserService.getDebateUserByUserName(message.getUserName());
+					FlagType flag;
+					if (message.getPosition().equals("pro")) {
+						flag = FlagType.PRO;
+					} else if (message.getPosition().equals("con")) {
+						flag = FlagType.CON;
+					} else {
+						flag = FlagType.NO_POSITION;
+					}
+					if (debateUser == null) {
+						return null;
+					}
+					return DebateChat.builder()
+						.debate(debate)
+						.debateUser(debateUser)
+						.flagType(flag)
+						.content(message.getMessage())
+						.time(message.getTime())
+						.build();
+				} else {
+					return null;
+				}
+			})
+			.filter(Objects::nonNull)
+			.toList();
+		
+		int batchSize = 100;
+		for (int i = 0; i < chatList.size(); i += batchSize) {
+			int end = Math.min(i + batchSize, chatList.size());
+			List<DebateChat> batch = chatList.subList(i, end);
+			debateChatRepository.saveAll(batch);
+			// 필요한 경우 flush()를 호출하여 DB에 즉시 반영할 수 있습니다.
+			debateChatRepository.flush();
+		}
+
+	}
+}

--- a/src/main/java/com/example/earthtalk/domain/debate/service/DebateManagementService.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/service/DebateManagementService.java
@@ -1,6 +1,7 @@
 package com.example.earthtalk.domain.debate.service;
 
 import java.util.Set;
+import java.util.UUID;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -58,6 +59,7 @@ public class DebateManagementService {
 		if (chatRoom != null && chatRoom.isFull()) {
 			Debate debate = Debate.builder()
 				.title(chatRoom.getTitle())
+				.uuid(UUID.fromString(roomId))
 				.description(chatRoom.getSubtitle())
 				.member(chatRoom.getMemberNumberType())
 				.continent(chatRoom.getContinent())

--- a/src/main/java/com/example/earthtalk/domain/debate/service/DebateService.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/service/DebateService.java
@@ -1,0 +1,24 @@
+package com.example.earthtalk.domain.debate.service;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import com.example.earthtalk.domain.debate.entity.Debate;
+import com.example.earthtalk.domain.debate.repository.DebateRepository;
+import com.example.earthtalk.global.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DebateService {
+
+	private final DebateRepository debateRepository;
+
+
+	protected Debate getDebateByRoomId(String roomId) {
+		return debateRepository.findByUuid(UUID.fromString(roomId))
+			.orElseThrow(() -> new IllegalArgumentException(ErrorCode.DEBATEROOM_NOT_FOUND.getMessage()));
+	}
+}

--- a/src/main/java/com/example/earthtalk/domain/debate/service/DebateUserService.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/service/DebateUserService.java
@@ -1,14 +1,16 @@
 package com.example.earthtalk.domain.debate.service;
 
-import java.util.Set;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Set;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
+import com.example.earthtalk.domain.debate.store.DebateUserStore;
+import com.example.earthtalk.domain.debate.entity.DebateUser;
 import com.example.earthtalk.domain.debate.model.ChatRoom;
+import com.example.earthtalk.domain.debate.repository.DebateUserRepository;
 import com.example.earthtalk.domain.user.repository.UserRepository;
 import com.example.earthtalk.global.exception.ErrorCode;
 import com.example.earthtalk.global.exception.ConflictException;
@@ -18,33 +20,35 @@ import com.example.earthtalk.global.exception.ConflictException;
  * <p>
  * 이 서비스는 찬성(pro)과 반대(con) 입장 그룹으로 사용자를 구분하며, 동시에
  * WebSocket 메시지 전송을 통해 클라이언트에 입장/퇴장 및 사용자 수 변경 이벤트를 알립니다.
+ * 사용자 상태 관리를 별도의 ChatUserStore 컴포넌트에 위임하여, 관심사의 분리 및 향후 분산 캐시 전환에 대비합니다.
  * </p>
  */
 @Service
 @RequiredArgsConstructor
 public class DebateUserService {
+
 	private final SimpMessagingTemplate messagingTemplate;
 	private final DebateManagementService debateManagementService;
-
-	private final Map<String, Set<String>> proUsers = new ConcurrentHashMap<>();
-
-	private final Map<String, Set<String>> conUsers = new ConcurrentHashMap<>();
 	private final ChatRoomService chatRoomService;
 	private final UserRepository userRepository;
+	private final DebateUserRepository debateUserRepository;
+
+	// 사용자 상태 관리를 담당하는 별도의 컴포넌트
+	private final DebateUserStore debateUserStore;
 
 	/**
 	 * 토론방에 사용자를 추가합니다.
 	 * <p>
 	 * 사용자의 포지션이 "pro" 또는 "con"에 따라 적절한 사용자 집합에 추가하고,
 	 * 입장 시 WebSocket 메시지로 클라이언트에 알립니다.
-	 * 방의 최대 인원 수는 roomType 파라미터로 제한하며, roomType은 1 또는 3만 허용됩니다.
+	 * 방의 최대 인원 수는 chatRoom의 MemberNumberType에 의해 제한되며, 허용되는 최대 인원은 1 또는 3입니다.
 	 * </p>
 	 *
 	 * @param chatRoom chatRoom model
 	 * @param userName 사용자 이름
 	 * @param position 사용자의 포지션 ("pro" 또는 "con")
-	 * @throws IllegalArgumentException maxMembers가 1 또는 3이 아닌 경우, 또는 position이 올바르지 않은 경우 발생
-	 * @throws ConflictException        이미 최대 인원 수가 초과된 경우 발생
+	 * @throws IllegalArgumentException 최대 인원이 1 또는 3이 아닌 경우, 또는 position이 올바르지 않은 경우 발생
+	 * @throws ConflictException        이미 최대 인원 수를 초과한 경우 발생
 	 */
 	public void addUser(ChatRoom chatRoom, String userName, String position) {
 		int maxMembers = chatRoom.getMemberNumberType().getValue();
@@ -53,17 +57,17 @@ public class DebateUserService {
 			throw new IllegalArgumentException(ErrorCode.METHOD_NOT_ALLOWED.getMessage());
 		}
 		if ("pro".equalsIgnoreCase(position)) {
-			proUsers.putIfAbsent(roomId, ConcurrentHashMap.newKeySet());
-			if (proUsers.get(roomId).size() < maxMembers) {
-				proUsers.get(roomId).add(userName);
-				sendUserJoinMessage(roomId, String.valueOf(userName));
+			Set<String> proSet = debateUserStore.getProUsers(roomId);
+			if (proSet.size() < maxMembers) {
+				proSet.add(userName);
+				sendUserJoinMessage(roomId, userName);
 			} else {
 				throw new ConflictException(ErrorCode.TOO_MANY_PARTICIPANTS);
 			}
-		}else if ("con".equalsIgnoreCase(position)) {
-			conUsers.putIfAbsent(roomId, ConcurrentHashMap.newKeySet());
-			if (conUsers.get(roomId).size() < maxMembers) {
-				conUsers.get(roomId).add(userName);
+		} else if ("con".equalsIgnoreCase(position)) {
+			Set<String> conSet = debateUserStore.getConUsers(roomId);
+			if (conSet.size() < maxMembers) {
+				conSet.add(userName);
 				sendUserJoinMessage(roomId, userName);
 			} else {
 				throw new ConflictException(ErrorCode.TOO_MANY_PARTICIPANTS);
@@ -74,58 +78,16 @@ public class DebateUserService {
 
 		sendUserCountUpdate(roomId);
 
-		if (proUsers.getOrDefault(roomId, Set.of()).size() == maxMembers &&
-			conUsers.getOrDefault(roomId, Set.of()).size() == maxMembers) {
+		if (debateUserStore.getProUsers(roomId).size() == maxMembers &&
+			debateUserStore.getConUsers(roomId).size() == maxMembers) {
 			debateManagementService.persistChatRoomIfFull(
 				roomId,
-				proUsers.get(roomId),
-				conUsers.get(roomId)
+				debateUserStore.getProUsers(roomId),
+				debateUserStore.getConUsers(roomId)
 			);
-			proUsers.remove(roomId);
-			conUsers.remove(roomId);
+			debateUserStore.removeProUsers(roomId);
+			debateUserStore.removeConUsers(roomId);
 		}
-
-	}
-
-	/**
-	 * 토론방에서 사용자가 퇴장할 때 호출되는 메서드입니다.
-	 * <p>
-	 * 찬성 또는 반대 사용자 집합에서 해당 사용자를 제거하며,
-	 * 사용자가 제거된 경우 클라이언트에 사용자 수 업데이트 및 퇴장 메시지를 전송합니다.
-	 * </p>
-	 *
-	 * @param roomId   토론방 ID
-	 * @param userName 퇴장하는 사용자 이름
-	 */
-	private void sendUserLeftMessage(String roomId, String userName) {
-		Map<String, String> message = Map.of(
-			"event", "user_left",
-			"roomId", roomId,
-			"userName", userName,
-			"message", userName + "님이 방을 떠났습니다."
-		);
-
-		messagingTemplate.convertAndSend("/topic/debate/" + roomId, message);
-	}
-
-	/**
-	 * 사용자가 토론방에 입장했을 때, 클라이언트에 입장 메시지를 전송합니다.
-	 * <p>
-	 * 전송되는 메시지는 사용자의 입장을 알리며, "/topic/debate/{roomId}" 경로로 전달됩니다.
-	 * </p>
-	 *
-	 * @param roomId   토론방 ID
-	 * @param userName 입장한 사용자 이름
-	 */
-	private void sendUserJoinMessage(String roomId, String userName) {
-		Map<String, String> userJoinedMessage = Map.of(
-			"event", "user_joined",
-			"roomId", roomId,
-			"userName", userName,
-			"message", userName + "님이 방에 입장했습니다."
-		);
-
-		messagingTemplate.convertAndSend("/topic/debate/" + roomId, userJoinedMessage);
 	}
 
 	/**
@@ -141,17 +103,19 @@ public class DebateUserService {
 	public void removeUser(String roomId, String userName) {
 		boolean removed = false;
 
-		if (proUsers.containsKey(roomId)) {
-			removed = proUsers.get(roomId).remove(userName);
-			if (proUsers.get(roomId).isEmpty()) {
-				proUsers.remove(roomId);
+		Set<String> proSet = debateUserStore.getProUsers(roomId);
+		if (proSet.contains(userName)) {
+			removed = proSet.remove(userName);
+			if (proSet.isEmpty()) {
+				debateUserStore.removeProUsers(roomId);
 			}
 		}
 
-		if (conUsers.containsKey(roomId)) {
-			removed = conUsers.get(roomId).remove(userName) || removed;
-			if (conUsers.get(roomId).isEmpty()) {
-				conUsers.remove(roomId);
+		Set<String> conSet = debateUserStore.getConUsers(roomId);
+		if (conSet.contains(userName)) {
+			removed = conSet.remove(userName) || removed;
+			if (conSet.isEmpty()) {
+				debateUserStore.removeConUsers(roomId);
 			}
 		}
 
@@ -161,7 +125,6 @@ public class DebateUserService {
 		}
 	}
 
-
 	/**
 	 * 주어진 토론방의 현재 사용자 수를 반환합니다.
 	 *
@@ -170,8 +133,8 @@ public class DebateUserService {
 	 */
 	public Map<String, Integer> getUserCount(String roomId) {
 		return Map.of(
-			"pro", proUsers.getOrDefault(roomId, Set.of()).size(),
-			"con", conUsers.getOrDefault(roomId, Set.of()).size()
+			"pro", debateUserStore.getProUsers(roomId).size(),
+			"con", debateUserStore.getConUsers(roomId).size()
 		);
 	}
 
@@ -187,4 +150,54 @@ public class DebateUserService {
 		messagingTemplate.convertAndSend("/topic/debate/" + roomId, getUserCount(roomId));
 	}
 
+	/**
+	 * 토론방에 사용자가 입장했을 때, 입장 메시지를 전송합니다.
+	 * <p>
+	 * 메시지는 "/topic/debate/{roomId}" 경로로 전송되며, 사용자 입장을 알립니다.
+	 * </p>
+	 *
+	 * @param roomId   토론방 ID
+	 * @param userName 입장한 사용자 이름
+	 */
+	private void sendUserJoinMessage(String roomId, String userName) {
+		Map<String, String> userJoinedMessage = Map.of(
+			"event", "user_joined",
+			"roomId", roomId,
+			"userName", userName,
+			"message", userName + "님이 방에 입장했습니다."
+		);
+		messagingTemplate.convertAndSend("/topic/debate/" + roomId, userJoinedMessage);
+	}
+
+	/**
+	 * 토론방에서 사용자가 퇴장할 때, 퇴장 메시지를 전송합니다.
+	 * <p>
+	 * 메시지는 "/topic/debate/{roomId}" 경로로 전송되며, 사용자 퇴장을 알립니다.
+	 * </p>
+	 *
+	 * @param roomId   토론방 ID
+	 * @param userName 퇴장하는 사용자 이름
+	 */
+	private void sendUserLeftMessage(String roomId, String userName) {
+		Map<String, String> message = Map.of(
+			"event", "user_left",
+			"roomId", roomId,
+			"userName", userName,
+			"message", userName + "님이 방을 떠났습니다."
+		);
+		messagingTemplate.convertAndSend("/topic/debate/" + roomId, message);
+	}
+
+	/**
+	 * 주어진 사용자 이름에 해당하는 DebateUser 객체를 반환합니다.
+	 * 만약 DebateUser를 찾을 수 없으면, USER_NOT_FOUND 오류 메시지와 함께 예외를 발생시킵니다.
+	 *
+	 * @param userName 사용자 이름
+	 * @return DebateUser 객체
+	 * @throws IllegalArgumentException DebateUser가 존재하지 않을 경우
+	 */
+	protected DebateUser getDebateUserByUserName(String userName) {
+		return debateUserRepository.findByUser_Nickname(userName)
+			.orElseThrow(() -> new IllegalArgumentException(ErrorCode.USER_NOT_FOUND.getMessage()));
+	}
 }

--- a/src/main/java/com/example/earthtalk/domain/debate/service/ObserverMessageService.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/service/ObserverMessageService.java
@@ -20,7 +20,7 @@ public class ObserverMessageService {
 	private final SimpMessagingTemplate messagingTemplate;
 
 	public void sendObserverMessage(ObserverMessage message) {
-		String destination = "/topic/observer/" + message.getRoomId();
+		String destination = "/topic/observer/" + message.getUuid();
 		messagingTemplate.convertAndSend(destination, message);
 	}
 }

--- a/src/main/java/com/example/earthtalk/domain/debate/store/ChatMessageStore.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/store/ChatMessageStore.java
@@ -1,0 +1,74 @@
+package com.example.earthtalk.domain.debate.store;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Component;
+
+import com.example.earthtalk.domain.debate.dto.DebateMessage;
+
+/**
+ * ChatMessageStore는 채팅방(roomId)별로 DebateMessage를 인메모리로 저장하고 관리하는 컴포넌트입니다.
+ * <p>
+ * 이 클래스는 채팅 메시지를 추가, 조회, 삭제하는 메서드를 제공하며,
+ * 여러 스레드에서 안전하게 접근할 수 있도록 ConcurrentHashMap을 사용합니다.
+ * </p>
+ */
+@Component
+public class ChatMessageStore {
+
+	/**
+	 * 채팅방 ID를 키(key)로, 해당 채팅방의 DebateMessage 리스트를 값(value)으로 갖는 맵.
+	 */
+	private final Map<String, List<DebateMessage>> chatMessagesMap = new ConcurrentHashMap<>();
+
+	/**
+	 * 지정된 roomId에 해당하는 DebateMessage 리스트를 반환합니다.
+	 * <p>
+	 * 만약 해당 roomId가 존재하지 않는다면, 새로운 ArrayList를 생성하여 맵에 추가한 후 반환합니다.
+	 * </p>
+	 *
+	 * @param roomId 채팅방의 식별자
+	 * @return 해당 채팅방의 DebateMessage 리스트
+	 */
+	public List<DebateMessage> getOrCreateChatMessages(String roomId) {
+		return chatMessagesMap.computeIfAbsent(roomId, k -> new ArrayList<>());
+	}
+
+	/**
+	 * 지정된 roomId에 DebateMessage를 추가합니다.
+	 *
+	 * @param roomId  채팅방의 식별자
+	 * @param message 추가할 DebateMessage 객체
+	 */
+	public void addChatMessage(String roomId, DebateMessage message) {
+		getOrCreateChatMessages(roomId).add(message);
+	}
+
+	/**
+	 * 지정된 roomId에 해당하는 모든 DebateMessage 리스트를 제거하고 반환합니다.
+	 * <p>
+	 * 만약 해당 roomId가 존재하지 않으면, null을 반환합니다.
+	 * </p>
+	 *
+	 * @param roomId 채팅방의 식별자
+	 * @return 제거된 DebateMessage 리스트, 존재하지 않으면 null
+	 */
+	public List<DebateMessage> removeChatMessages(String roomId) {
+		return chatMessagesMap.remove(roomId);
+	}
+
+	/**
+	 * 저장된 모든 채팅 메시지 맵을 반환합니다.
+	 * <p>
+	 * 이 메서드는 디버깅이나 관리 용도로 사용될 수 있습니다.
+	 * </p>
+	 *
+	 * @return 채팅방 ID와 DebateMessage 리스트의 맵
+	 */
+	public Map<String, List<DebateMessage>> getAllChatMessages() {
+		return chatMessagesMap;
+	}
+}

--- a/src/main/java/com/example/earthtalk/domain/debate/store/ChatRoomStore.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/store/ChatRoomStore.java
@@ -1,0 +1,58 @@
+package com.example.earthtalk.domain.debate.store;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Component;
+
+import com.example.earthtalk.domain.debate.model.ChatRoom;
+
+/**
+ * ChatRoomStore는 채팅방 정보를 인메모리 캐시에 저장하고 관리하는 컴포넌트입니다.
+ * <p>
+ * 이 클래스는 채팅방의 고유 식별자(roomId)를 키(key)로, 해당 채팅방 정보를 담은 {@link ChatRoom} 객체를 값(value)으로 저장합니다.
+ * ConcurrentHashMap을 사용하여 여러 스레드에서 안전하게 접근할 수 있습니다.
+ * </p>
+ */
+@Component
+public class ChatRoomStore {
+
+	private final Map<String, ChatRoom> chatRoomCache = new ConcurrentHashMap<>();
+
+	/**
+	 * 주어진 채팅방 정보를 캐시에 저장합니다.
+	 *
+	 * @param chatRoom 저장할 {@link ChatRoom} 객체
+	 */
+	public void put(ChatRoom chatRoom) {
+		chatRoomCache.put(chatRoom.getRoomId(), chatRoom);
+	}
+
+	/**
+	 * 주어진 roomId에 해당하는 채팅방 정보를 반환합니다.
+	 *
+	 * @param roomId 채팅방의 고유 식별자
+	 * @return 해당 roomId에 해당하는 {@link ChatRoom} 객체, 존재하지 않으면 null
+	 */
+	public ChatRoom get(String roomId) {
+		return chatRoomCache.get(roomId);
+	}
+
+	/**
+	 * 주어진 roomId에 해당하는 채팅방 정보를 캐시에서 제거합니다.
+	 *
+	 * @param roomId 채팅방의 고유 식별자
+	 */
+	public void remove(String roomId) {
+		chatRoomCache.remove(roomId);
+	}
+
+	/**
+	 * 현재 캐시에 저장된 모든 채팅방 정보를 반환합니다.
+	 *
+	 * @return 모든 채팅방 정보를 담은 Map
+	 */
+	public Map<String, ChatRoom> getAll() {
+		return chatRoomCache;
+	}
+}

--- a/src/main/java/com/example/earthtalk/domain/debate/store/DebateUserStore.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/store/DebateUserStore.java
@@ -1,0 +1,59 @@
+package com.example.earthtalk.domain.debate.store;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+
+/**
+ * ChatUserStore는 각 채팅방(roomId)별로 찬성(pro) 및 반대(con) 사용자 목록을 관리하는 컴포넌트입니다.
+ * <p>
+ * 이 클래스는 스레드 안전한 ConcurrentHashMap과 ConcurrentHashMap.newKeySet()을 사용하여
+ * 각 채팅방의 사용자 집합을 저장하고, 추가/삭제/조회 기능을 제공합니다.
+ * </p>
+ */
+@Component
+public class DebateUserStore {
+
+	private final ConcurrentHashMap<String, Set<String>> proUsers = new ConcurrentHashMap<>();
+	private final ConcurrentHashMap<String, Set<String>> conUsers = new ConcurrentHashMap<>();
+
+	/**
+	 * 주어진 채팅방 ID에 대한 찬성 사용자 집합을 반환합니다.
+	 * 만약 해당 채팅방이 없으면, 새로운 집합을 생성하여 반환합니다.
+	 *
+	 * @param roomId 채팅방 식별자
+	 * @return 찬성 사용자 집합
+	 */
+	public Set<String> getProUsers(String roomId) {
+		return proUsers.computeIfAbsent(roomId, k -> ConcurrentHashMap.newKeySet());
+	}
+
+	/**
+	 * 주어진 채팅방 ID에 대한 반대 사용자 집합을 반환합니다.
+	 * 만약 해당 채팅방이 없으면, 새로운 집합을 생성하여 반환합니다.
+	 *
+	 * @param roomId 채팅방 식별자
+	 * @return 반대 사용자 집합
+	 */
+	public Set<String> getConUsers(String roomId) {
+		return conUsers.computeIfAbsent(roomId, k -> ConcurrentHashMap.newKeySet());
+	}
+
+	/**
+	 * 주어진 채팅방 ID의 찬성 사용자 집합을 제거합니다.
+	 *
+	 * @param roomId 채팅방 식별자
+	 */
+	public void removeProUsers(String roomId) {
+		proUsers.remove(roomId);
+	}
+
+	/**
+	 * 주어진 채팅방 ID의 반대 사용자 집합을 제거합니다.
+	 *
+	 * @param roomId 채팅방 식별자
+	 */
+	public void removeConUsers(String roomId) {
+		conUsers.remove(roomId);
+	}
+}

--- a/src/main/java/com/example/earthtalk/domain/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/example/earthtalk/domain/user/dto/response/UserInfoResponse.java
@@ -16,7 +16,7 @@ public record UserInfoResponse(
         return new UserInfoResponse(
             user.getId(),
             user.getNickname(),
-            user.getProfile(),
+            user.getProfileUrl(),
             user.getIntroduction(),
             totalFollowers,
             totalFollowees,

--- a/src/main/java/com/example/earthtalk/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/earthtalk/global/exception/ErrorCode.java
@@ -37,7 +37,8 @@ public enum ErrorCode { // 예외 발생시, body에 실어 날려줄 상태, co
     REPORT_NOT_FOUND(404, -4000, "조회된 신고가 존재하지 않습니다."),
     CHAT_NOT_FOUND(404, -4001, "조회된 채팅이 존재하지 않습니다."),
     //-5000 비즈니스 로직2
-    TOO_MANY_PARTICIPANTS(409, -5001, "참가자가 이미 최대 인원 입니다.");
+    TOO_MANY_PARTICIPANTS(409, -5001, "참가자가 이미 최대 인원 입니다."),
+    DEBATEROOM_NOT_FOUND(404, -5002, "토론방 내역을 찾을 수 없습니다.");
 
     // 1. status = 날려줄 상태코드
     // 2. code = 해당 오류가 어느부분과 관련있는지 카테고리화 해주는 코드. 예외 원인 식별하기 편하기에 추가

--- a/src/test/java/com/example/earthtalk/domain/debate/component/WebSocketEventListenerTest.java
+++ b/src/test/java/com/example/earthtalk/domain/debate/component/WebSocketEventListenerTest.java
@@ -1,99 +1,186 @@
 package com.example.earthtalk.domain.debate.component;
 
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Map;
+import java.time.LocalDateTime;
+import java.util.*;
 
-import com.example.earthtalk.domain.debate.dto.SessionInfo;
+import com.example.earthtalk.domain.debate.dto.DebateMessage;
 import com.example.earthtalk.domain.debate.model.ChatRoom;
 import com.example.earthtalk.domain.debate.service.ChatRoomService;
+import com.example.earthtalk.domain.debate.service.DebateChatService;
 import com.example.earthtalk.domain.debate.service.DebateUserService;
-import com.example.earthtalk.global.exception.BadRequestException;
-import com.example.earthtalk.global.exception.ErrorCode;
+import com.example.earthtalk.domain.debate.store.ChatMessageStore;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.messaging.SessionConnectedEvent;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 
+/**
+ * WebSocketEventListener의 WebSocket 연결 및 해제 이벤트를 테스트하는 클래스.
+ */
+@ExtendWith(MockitoExtension.class)
 public class WebSocketEventListenerTest {
 
+	@Mock
 	private DebateUserService debateUserService;
+
+	@Mock
 	private ChatRoomService chatRoomService;
+
+	@Mock
+	private DebateChatService debateChatService;
+
+	// 실제 구현을 사용하는 Spy 객체
+	@Spy
+	private ChatMessageStore chatMessageStore = new ChatMessageStore();
+
+	@InjectMocks
 	private WebSocketEventListener eventListener;
+
+	/**
+	 * 연결 이벤트를 시뮬레이션하여 sessionInfoMap에 세션 정보를 등록합니다.
+	 * 이때, 주어진 roomId에 대해 chatRoomService.getChatRoom()이 올바른 ChatRoom을 반환하도록 stubbing합니다.
+	 *
+	 * @param sessionId 세션 ID
+	 * @param roomId    채팅방 ID
+	 * @param userName  사용자 이름
+	 * @param position  사용자 포지션 ("pro" 또는 "con")
+	 */
+	private void simulateConnection(String sessionId, String roomId, String userName, String position) {
+		// roomId에 대해 ChatRoom 객체를 반환하도록 stubbing
+		ChatRoom chatRoom = new ChatRoom(roomId, null, "Test Room", "Test Subtitle", null, null, null);
+		when(chatRoomService.getChatRoom(roomId)).thenReturn(chatRoom);
+
+		Map<String, Object> sessionAttributes = new HashMap<>();
+		sessionAttributes.put("roomId", roomId);
+		sessionAttributes.put("userName", userName);
+		sessionAttributes.put("position", position);
+
+		StompHeaderAccessor connectAccessor = StompHeaderAccessor.create(StompCommand.CONNECTED);
+		connectAccessor.setSessionAttributes(sessionAttributes);
+		connectAccessor.setSessionId(sessionId);
+		Message<byte[]> connectMessage = MessageBuilder.createMessage("dummy".getBytes(StandardCharsets.UTF_8),
+			connectAccessor.getMessageHeaders());
+		SessionConnectedEvent connectEvent = new SessionConnectedEvent(this, connectMessage);
+		eventListener.handleWebSocketConnectListener(connectEvent);
+	}
 
 	@BeforeEach
 	public void setUp() {
-		debateUserService = mock(DebateUserService.class);
-		chatRoomService = mock(ChatRoomService.class);
-		eventListener = new WebSocketEventListener(debateUserService, chatRoomService);
+		// 불필요한 전역 stubbing은 제거하고, 각 테스트마다 필요한 stubbing을 개별적으로 설정합니다.
 	}
 
 	@Test
 	public void testHandleWebSocketConnectListener_Valid() {
-		// 세션 속성 맵 생성
 		Map<String, Object> sessionAttributes = new HashMap<>();
 		sessionAttributes.put("roomId", "room123");
 		sessionAttributes.put("userName", "testUser");
 		sessionAttributes.put("position", "pro");
 
-		// StompHeaderAccessor 생성 (CONNECTED 커맨드를 사용)
+		// ChatRoom stub 설정
+		ChatRoom chatRoom = new ChatRoom("room123", null, "Test Room", "Test Subtitle", null, null, null);
+		when(chatRoomService.getChatRoom("room123")).thenReturn(chatRoom);
+
 		StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECTED);
 		accessor.setSessionAttributes(sessionAttributes);
 		accessor.setSessionId("session123");
-		Message<byte[]> message = MessageBuilder.createMessage("dummy".getBytes(StandardCharsets.UTF_8), accessor.getMessageHeaders());
-
-		// CONNECTED 이벤트 생성 (source로 this를 전달)
+		Message<byte[]> message = MessageBuilder.createMessage("dummy".getBytes(StandardCharsets.UTF_8),
+			accessor.getMessageHeaders());
 		SessionConnectedEvent connectEvent = new SessionConnectedEvent(this, message);
 
-		// chatRoomService가 "room123"에 대해 ChatRoom 객체를 반환하도록 stub 설정
-		ChatRoom chatRoom = new ChatRoom("room123", /*MemberNumberType*/ null, "Test Room", "Test Subtitle", null, null, null);
-		// 실제 테스트에서는 MemberNumberType, TimeType, CategoryType, ContinentType을 적절히 설정해야 합니다.
-		when(chatRoomService.getChatRoom("room123")).thenReturn(chatRoom);
-
-		// 이벤트 처리
 		eventListener.handleWebSocketConnectListener(connectEvent);
 
-		// DebateUserService.addUser가 올바른 파라미터로 호출되었는지 검증
 		verify(debateUserService, times(1)).addUser(chatRoom, "testUser", "pro");
 	}
 
 	@Test
-	public void testHandleWebSocketDisconnectListener_Valid() {
-		// 먼저 연결 이벤트를 발생시켜 sessionInfoMap에 세션 정보를 저장합니다.
+	public void testHandleWebSocketConnectListener_InvalidRoom() {
 		Map<String, Object> sessionAttributes = new HashMap<>();
-		sessionAttributes.put("roomId", "room123");
+		sessionAttributes.put("roomId", "invalidRoom");
 		sessionAttributes.put("userName", "testUser");
 		sessionAttributes.put("position", "pro");
 
-		StompHeaderAccessor connectAccessor = StompHeaderAccessor.create(StompCommand.CONNECTED);
-		connectAccessor.setSessionAttributes(sessionAttributes);
-		connectAccessor.setSessionId("session123");
-		Message<byte[]> connectMessage = MessageBuilder.createMessage("dummy".getBytes(StandardCharsets.UTF_8), connectAccessor.getMessageHeaders());
-		SessionConnectedEvent connectEvent = new SessionConnectedEvent(this, connectMessage);
-		ChatRoom chatRoom = new ChatRoom("room123", /*MemberNumberType*/ null, "Test Room", "Test Subtitle", null, null, null);
-		when(chatRoomService.getChatRoom("room123")).thenReturn(chatRoom);
-		eventListener.handleWebSocketConnectListener(connectEvent);
+		StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECTED);
+		accessor.setSessionAttributes(sessionAttributes);
+		accessor.setSessionId("session123");
+		Message<byte[]> message = MessageBuilder.createMessage("dummy".getBytes(StandardCharsets.UTF_8),
+			accessor.getMessageHeaders());
+		SessionConnectedEvent connectEvent = new SessionConnectedEvent(this, message);
 
-		// 이제 연결 해제 이벤트를 생성합니다.
+		when(chatRoomService.getChatRoom("invalidRoom")).thenReturn(null);
+
+		assertThrows(RuntimeException.class, () -> eventListener.handleWebSocketConnectListener(connectEvent));
+	}
+
+	@Test
+	public void testHandleWebSocketDisconnectListener_WithoutMessages() {
+		// 먼저 연결 이벤트로 세션 정보 등록 (채팅 메시지 저장소에 메시지 없음)
+		simulateConnection("session123", "room123", "testUser", "pro");
+
+		// stubbing: 빈 리스트 반환
+		doReturn(Collections.emptyList()).when(chatMessageStore).removeChatMessages("room123");
+
 		StompHeaderAccessor disconnectAccessor = StompHeaderAccessor.create(StompCommand.DISCONNECT);
 		disconnectAccessor.setSessionId("session123");
-		// 연결 해제 이벤트의 메시지에는 세션 속성이 필요없으므로 단순하게 payload 생성
-		Message<byte[]> disconnectMessage = MessageBuilder.createMessage("dummy".getBytes(StandardCharsets.UTF_8), disconnectAccessor.getMessageHeaders());
-		// 최신 버전에서는 SessionDisconnectEvent 생성자가 source, message, sessionId, closeStatus를 요구합니다.
-		// closeStatus는 정상 종료를 의미하는 CloseStatus.NORMAL을 사용합니다.
-		org.springframework.web.socket.CloseStatus closeStatus = org.springframework.web.socket.CloseStatus.NORMAL;
+		Message<byte[]> disconnectMessage = MessageBuilder.createMessage("dummy".getBytes(StandardCharsets.UTF_8),
+			disconnectAccessor.getMessageHeaders());
+		CloseStatus closeStatus = CloseStatus.NORMAL;
 		SessionDisconnectEvent disconnectEvent = new SessionDisconnectEvent(this, disconnectMessage, "session123", closeStatus);
 
-		// 이벤트 처리
 		eventListener.handleWebSocketDisconnectListener(disconnectEvent);
 
-		// DebateUserService.removeUser가 올바른 파라미터로 호출되었는지 검증
-		verify(debateUserService, times(1)).removeUser("room123", "testUser");
+		// saveChatHistory가 호출되지 않아야 함
+		verify(debateChatService, times(0)).saveChatHistory(anyString(), anyList());
+	}
+
+	@Test
+	public void testHandleWebSocketDisconnectListener_WithMessages() {
+		// 먼저 연결 이벤트로 세션 정보 등록
+		simulateConnection("session123", "room123", "testUser", "pro");
+
+		// stubbing: room123에 대해 mockMessages 반환
+		List<DebateMessage> mockMessages = new ArrayList<>();
+		mockMessages.add(new DebateMessage("chat", "testUser", "pro", "Hello!", LocalDateTime.now()));
+		doReturn(mockMessages).when(chatMessageStore).removeChatMessages("room123");
+
+		StompHeaderAccessor disconnectAccessor = StompHeaderAccessor.create(StompCommand.DISCONNECT);
+		disconnectAccessor.setSessionId("session123");
+		Message<byte[]> disconnectMessage = MessageBuilder.createMessage("dummy".getBytes(StandardCharsets.UTF_8),
+			disconnectAccessor.getMessageHeaders());
+		CloseStatus closeStatus = CloseStatus.NORMAL;
+		SessionDisconnectEvent disconnectEvent = new SessionDisconnectEvent(this, disconnectMessage, "session123", closeStatus);
+
+		eventListener.handleWebSocketDisconnectListener(disconnectEvent);
+
+		// verify: debateChatService.saveChatHistory가 "room123"과 mockMessages로 호출되었는지
+		verify(debateChatService, times(1)).saveChatHistory(eq("room123"), eq(mockMessages));
+	}
+
+	@Test
+	public void testChatMessageStore_AddAndRemove() {
+		// 실제 ChatMessageStore의 add 및 remove 기능 검증
+		String roomId = "room123";
+		DebateMessage message = new DebateMessage("chat", "testUser", "pro", "Hello!", LocalDateTime.now());
+
+		chatMessageStore.addChatMessage(roomId, message);
+		List<DebateMessage> messages = chatMessageStore.removeChatMessages(roomId);
+
+		assertEquals(1, messages.size());
+		assertEquals("Hello!", messages.get(0).getMessage());
 	}
 }

--- a/src/test/java/com/example/earthtalk/domain/debate/service/DebateChatServiceTest.java
+++ b/src/test/java/com/example/earthtalk/domain/debate/service/DebateChatServiceTest.java
@@ -1,0 +1,144 @@
+package com.example.earthtalk.domain.debate.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import com.example.earthtalk.domain.debate.dto.DebateMessage;
+import com.example.earthtalk.domain.debate.entity.Debate;
+import com.example.earthtalk.domain.debate.entity.DebateChat;
+import com.example.earthtalk.domain.debate.entity.DebateUser;
+import com.example.earthtalk.domain.debate.entity.FlagType;
+import com.example.earthtalk.domain.debate.repository.DebateChatRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class DebateChatServiceTest {
+
+	@Mock
+	private DebateChatRepository debateChatRepository;
+
+	@Mock
+	private DebateUserService debateUserService;
+
+	@Mock
+	private DebateService debateService;
+
+	@InjectMocks
+	private DebateChatService debateChatService;
+
+	private Debate mockDebate;
+	private DebateUser mockDebateUser;
+	private LocalDateTime now;
+
+	@BeforeEach
+	public void setUp() {
+		mockDebate = mock(Debate.class);
+		mockDebateUser = mock(DebateUser.class);
+		now = LocalDateTime.now();
+	}
+
+	@Test
+	public void testSaveChatHistory_withValidMessage() {
+		String uuid = "room-uuid";
+		DebateMessage message = new DebateMessage("chat", "user1", "pro", "Hello", now);
+		List<DebateMessage> messages = Collections.singletonList(message);
+
+		when(debateService.getDebateByRoomId(uuid)).thenReturn(mockDebate);
+		when(debateUserService.getDebateUserByUserName("user1")).thenReturn(mockDebateUser);
+
+		debateChatService.saveChatHistory(uuid, messages);
+
+		ArgumentCaptor<List<DebateChat>> captor = ArgumentCaptor.forClass(List.class);
+		verify(debateChatRepository, times(1)).saveAll(captor.capture());
+		List<DebateChat> savedChats = captor.getValue();
+		assertEquals(1, savedChats.size());
+		DebateChat savedChat = savedChats.get(0);
+		assertEquals(mockDebate, savedChat.getDebate());
+		assertEquals(mockDebateUser, savedChat.getDebateUser());
+		assertEquals(FlagType.PRO, savedChat.getFlagType());
+		assertEquals("Hello", savedChat.getContent());
+		assertEquals(now, savedChat.getTime());
+	}
+
+	@Test
+	public void testSaveChatHistory_withInvalidEvent() {
+		String uuid = "room-uuid";
+		DebateMessage message = new DebateMessage("update", "user1", "pro", "Ignored", now);
+		List<DebateMessage> messages = Collections.singletonList(message);
+
+		when(debateService.getDebateByRoomId(uuid)).thenReturn(mockDebate);
+		// "user1"은 실제로 호출되지 because event != "chat", 따라서 lenient stubbing 사용
+		lenient().when(debateUserService.getDebateUserByUserName("user1")).thenReturn(mockDebateUser);
+
+		debateChatService.saveChatHistory(uuid, messages);
+
+		ArgumentCaptor<List<DebateChat>> captor = ArgumentCaptor.forClass(List.class);
+		verify(debateChatRepository, times(1)).saveAll(captor.capture());
+		List<DebateChat> savedChats = captor.getValue();
+		// Expecting empty list because the message event is not "chat"
+		assertTrue(savedChats.isEmpty());
+	}
+
+	@Test
+	public void testSaveChatHistory_withNullDebateUser() {
+		String uuid = "room-uuid";
+		DebateMessage message = new DebateMessage("chat", "user1", "pro", "Hello", now);
+		List<DebateMessage> messages = Collections.singletonList(message);
+
+		when(debateService.getDebateByRoomId(uuid)).thenReturn(mockDebate);
+		when(debateUserService.getDebateUserByUserName("user1")).thenReturn(null);
+
+		debateChatService.saveChatHistory(uuid, messages);
+
+		ArgumentCaptor<List<DebateChat>> captor = ArgumentCaptor.forClass(List.class);
+		verify(debateChatRepository, times(1)).saveAll(captor.capture());
+		List<DebateChat> savedChats = captor.getValue();
+		// Null DebateUser should lead to filtering out the message
+		assertTrue(savedChats.isEmpty());
+	}
+
+	@Test
+	public void testSaveChatHistory_withMultipleMessages() {
+		String uuid = "room-uuid";
+		DebateMessage validMessage1 = new DebateMessage("chat", "user1", "pro", "Hello", now);
+		DebateMessage validMessage2 = new DebateMessage("chat", "user2", "con", "Hi", now.plusMinutes(1));
+		DebateMessage invalidMessage = new DebateMessage("update", "user3", "pro", "Update", now.plusMinutes(2));
+
+		List<DebateMessage> messages = Arrays.asList(validMessage1, validMessage2, invalidMessage);
+
+		when(debateService.getDebateByRoomId(uuid)).thenReturn(mockDebate);
+		when(debateUserService.getDebateUserByUserName("user1")).thenReturn(mockDebateUser);
+		DebateUser debateUser2 = mock(DebateUser.class);
+		when(debateUserService.getDebateUserByUserName("user2")).thenReturn(debateUser2);
+
+		debateChatService.saveChatHistory(uuid, messages);
+
+		ArgumentCaptor<List<DebateChat>> captor = ArgumentCaptor.forClass(List.class);
+		verify(debateChatRepository, times(1)).saveAll(captor.capture());
+		List<DebateChat> savedChats = captor.getValue();
+		assertEquals(2, savedChats.size());
+
+		List<String> contents = savedChats.stream().map(DebateChat::getContent).collect(Collectors.toList());
+		assertTrue(contents.contains("Hello"));
+		assertTrue(contents.contains("Hi"));
+
+		for (DebateChat chat : savedChats) {
+			if (chat.getContent().equals("Hello")) {
+				assertEquals(FlagType.PRO, chat.getFlagType());
+			} else if (chat.getContent().equals("Hi")) {
+				assertEquals(FlagType.CON, chat.getFlagType());
+			}
+		}
+	}
+}

--- a/src/test/java/com/example/earthtalk/domain/debate/service/ObserverMessageServiceTest.java
+++ b/src/test/java/com/example/earthtalk/domain/debate/service/ObserverMessageServiceTest.java
@@ -23,7 +23,7 @@ public class ObserverMessageServiceTest {
 	public void testSendObserverMessage() {
 		// ObserverMessage 객체 생성 (필요한 필드는 실제 클래스에 맞게 설정)
 		ObserverMessage message = new ObserverMessage();
-		message.setRoomId("room123");
+		message.setUuid("room123");
 		message.setMessage("Test Content"); // 예시로 content 필드가 있다고 가정
 
 		// sendObserverMessage 호출


### PR DESCRIPTION
📄 요약
> 채팅 DB 저장 기능

🙋🏻 More
WebSocket 연결/해제 이벤트 처리: WebSocketEventListener를 통해 클라이언트 연결 시 세션 정보를 저장하고, 입장 메시지를 전송하며, 연결 해제 시 해당 세션의 채팅 로그를 수집해 db에 배치 처리로 저장하고 사용자를 제거하는 기능을 구현했습니다.

채팅 메시지 관리: ChatMessageStore를 별도의 컴포넌트로 분리하여 각 채팅방(roomId)별로 메시지를 인메모리에서 안전하게 관리하도록 했으며, 필요 시 메시지를 추가, 조회, 제거할 수 있도록 했습니다.

채팅 로그 배치 저장: DebateChatService에서는 전달받은 DebateMessage들을 DebateChat 엔티티로 변환한 후, 배치 처리를 통해 데이터베이스에 저장하는 로직을 추가하여 대량 데이터 처리 시의 성능과 안정성을 개선했습니다.

사용자 상태 관리: 기존 DebateUserService 내에서 직접 관리하던 사용자 목록을 ChatUserStore와 같은 별도 컴포넌트로 분리하여, 찬성(pro)과 반대(con) 사용자 그룹을 효율적으로 관리하도록 패키지 구조를 개선했습니다.

✅ 피드백 반영사항 & 궁금한 점
