### PR TITLE
feat: 알림 기능 구현 및 가이드라인 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ out/
 .vscode/
 
 .env
+src/main/resources/firebase.json

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
     testImplementation 'com.h2database:h2'
-    
+
     //querydsl
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
@@ -56,6 +56,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
+    // Crawling
+    implementation group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '4.28.1'
+    implementation group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '5.9.2'
 
     // notifications - firebase
     implementation 'com.google.firebase:firebase-admin:9.4.3'

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
     testImplementation 'com.h2database:h2'
-
+    
     //querydsl
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
@@ -56,9 +56,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
-    // Crawling
-    implementation group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '4.28.1'
-    implementation group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '5.9.2'
+
+    // notifications - firebase
+    implementation 'com.google.firebase:firebase-admin:9.4.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/earthtalk/config/FirebaseConfig.java
+++ b/src/main/java/com/example/earthtalk/config/FirebaseConfig.java
@@ -1,0 +1,37 @@
+package com.example.earthtalk.config;
+
+import com.example.earthtalk.global.exception.BadRequestException;
+import com.example.earthtalk.global.exception.ErrorCode;
+import com.example.earthtalk.global.exception.NotFoundException;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import org.springframework.context.annotation.Configuration;
+
+import javax.annotation.PostConstruct;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+@Configuration
+public class FirebaseConfig {
+
+    @PostConstruct
+    public void init() {
+        try {
+            FileInputStream serviceAccount = new FileInputStream("src/main/resources/firebase.json");
+
+            FirebaseOptions options = new FirebaseOptions.Builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
+
+            if(FirebaseApp.getApps().isEmpty()) {
+                FirebaseApp.initializeApp(options);
+            }
+        } catch (FileNotFoundException e) {
+            throw new NotFoundException(ErrorCode.NOT_FOUND);
+        } catch (IOException e) {
+            throw new BadRequestException(ErrorCode.INVALID_REQUEST_BODY);
+        }
+    }
+}

--- a/src/main/java/com/example/earthtalk/controller/AdminController.java
+++ b/src/main/java/com/example/earthtalk/controller/AdminController.java
@@ -33,21 +33,21 @@ public class AdminController {
     }
 
     @GetMapping("/reports/{reportId}")
-    public ResponseEntity<ApiResponse<ReportDetailResponse>> getReportsById(@PathVariable("reportId") Long reportId) {
+    public ResponseEntity<ApiResponse<ReportDetailResponse>> getReportById(@PathVariable("reportId") Long reportId) {
         ReportDetailResponse report = reportService.getReportById(reportId);
         return ResponseEntity.ok(ApiResponse.createSuccess(report));
     }
 
     @PutMapping("/reports/{reportId}")
-    public ResponseEntity<ApiResponse<?>> putReportsById(@PathVariable("reportId") Long reportId,
-                                                              @RequestBody UpdateReportRequest request) {
+    public ResponseEntity<ApiResponse<Long>> putReportById(@PathVariable("reportId") Long reportId,
+                                                              @RequestBody UpdateReportRequest request) throws Exception{
         Long id = reportService.updateReport(reportId, request);
-        return ResponseEntity.ok(ApiResponse.createSuccessWithNoData());
+        return ResponseEntity.ok(ApiResponse.createSuccess(id));
     }
 
     @PutMapping("/reports/{reportId}/restore")
-    public ResponseEntity<ApiResponse<?>> putReportRestoreById(@PathVariable("reportId") Long reportId) {
+    public ResponseEntity<ApiResponse<Long>> putReportRestoreById(@PathVariable("reportId") Long reportId) {
         Long id = reportService.restoreReport(reportId);
-        return ResponseEntity.ok(ApiResponse.createSuccessWithNoData());
+        return ResponseEntity.ok(ApiResponse.createSuccess(id));
     }
 }

--- a/src/main/java/com/example/earthtalk/controller/AdminController.java
+++ b/src/main/java/com/example/earthtalk/controller/AdminController.java
@@ -7,13 +7,12 @@ import com.example.earthtalk.domain.report.entity.ReportType;
 import com.example.earthtalk.domain.report.entity.ResultType;
 import com.example.earthtalk.domain.report.service.ReportService;
 import com.example.earthtalk.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/admin")
@@ -22,6 +21,7 @@ public class AdminController {
 
     private final ReportService reportService;
 
+    @Operation(summary = "신고 조회 API 입니다.", description = "각 파라미터에 해당하는 값을 통해 조회된 신고들을 페이지네이션하여 반환합니다.")
     @GetMapping("/reports")
     public ResponseEntity<ApiResponse<Page<ReportListResponse>>> getReports(@RequestParam(value = "q", required = false) String q,
                                                           @RequestParam(value = "type", required = false) ReportType reportType,
@@ -32,12 +32,14 @@ public class AdminController {
         return ResponseEntity.ok(ApiResponse.createSuccess(reports));
     }
 
+    @Operation(summary = "신고 상세 조회 API 입니다.", description = "reportId 에 해당하는 신고의 상세한 정보를 조회합니다.")
     @GetMapping("/reports/{reportId}")
     public ResponseEntity<ApiResponse<ReportDetailResponse>> getReportById(@PathVariable("reportId") Long reportId) {
         ReportDetailResponse report = reportService.getReportById(reportId);
         return ResponseEntity.ok(ApiResponse.createSuccess(report));
     }
 
+    @Operation(summary = "신고 처리 API 입니다.", description = "reportId 에 해당하는 신고의 처리를 담당합니다.")
     @PutMapping("/reports/{reportId}")
     public ResponseEntity<ApiResponse<Long>> putReportById(@PathVariable("reportId") Long reportId,
                                                               @RequestBody UpdateReportRequest request) throws Exception{
@@ -45,6 +47,7 @@ public class AdminController {
         return ResponseEntity.ok(ApiResponse.createSuccess(id));
     }
 
+    @Operation(summary = "신고 복구 API 입니다.", description = "이미 처리된 신고를 미처리 상태로 복구합니다.")
     @PutMapping("/reports/{reportId}/restore")
     public ResponseEntity<ApiResponse<Long>> putReportRestoreById(@PathVariable("reportId") Long reportId) {
         Long id = reportService.restoreReport(reportId);

--- a/src/main/java/com/example/earthtalk/controller/NotificationController.java
+++ b/src/main/java/com/example/earthtalk/controller/NotificationController.java
@@ -65,8 +65,8 @@ public class NotificationController {
 
     // 사용자가 알림을 읽었을 때 status 값을 변경하기 위한 API
     @Operation(summary = "전송된 알림의 상태를 변경시키는 API 입니다.", description = "읽지 않은 알림에 대하여 읽음 상태로 변경 시킬 수 있습니다.")
-    @PostMapping("/read")
-    public ResponseEntity<ApiResponse<?>> readNotification(@RequestParam("notificationId") Long notificationId) {
+    @PostMapping("/{notificationId}/read")
+    public ResponseEntity<ApiResponse<?>> readNotification(@PathVariable("notificationId") Long notificationId) {
         notificationService.readNotification(notificationId);
         return ResponseEntity.ok(ApiResponse.createSuccessWithNoData());
     }

--- a/src/main/java/com/example/earthtalk/controller/NotificationController.java
+++ b/src/main/java/com/example/earthtalk/controller/NotificationController.java
@@ -5,6 +5,7 @@ import com.example.earthtalk.domain.notification.dto.request.SendNotificationReq
 import com.example.earthtalk.domain.notification.dto.response.NotificationListResponse;
 import com.example.earthtalk.domain.notification.service.NotificationService;
 import com.example.earthtalk.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -19,6 +20,7 @@ public class NotificationController {
     private final NotificationService notificationService;
 
     // 접속중인 사용자의 알림을 조회하기 위한 API.
+    @Operation(summary = "알림 조회 API 입니다.", description = "userId 의 값을 받아 해당하는 알림들을 조회합니다.")
     @GetMapping("")
     public ResponseEntity<ApiResponse<List<NotificationListResponse>>> getNotificationList(@RequestParam("userId") Long userId) {
         List<NotificationListResponse> responses = notificationService.getNotifications(userId);
@@ -26,6 +28,7 @@ public class NotificationController {
     }
 
     // FE 에서 전송한 토큰값을 저장하기 위한 API.
+    @Operation(summary = "FCM 토큰 저장 API 입니다.", description = "토큰 값과 userId 값을 통해 user 테이블에 해당하는 칼럼에 토큰 값을 추가합니다.")
     @PostMapping("/saveToken")
     public ResponseEntity<ApiResponse<?>> saveToken(@RequestBody SaveTokenRequest request) {
         notificationService.saveToken(request);
@@ -53,6 +56,7 @@ public class NotificationController {
      *   - Controller 의 send 는 FE 에서 한 행동에 대해 알림을 보내주기 위해 만든 API 입니다.
      *   - 실질적인 로직은 Service 에 있습니다. (자세한 내용은 Service 에서 설명)
      */
+    @Operation(summary = "알림 전송 API 입니다.", description = "userId 에 해당하는 user 에게 알림을 전송하며 알림 유형에 따라 문구가 바뀌고 typeId 를 통해 알림과 관련된 대상을 연결시킬 수 있습니다.")
     @PostMapping("/send")
     public ResponseEntity<ApiResponse<String>> sendNotification(@RequestBody SendNotificationRequest request) throws Exception{
         String response = notificationService.sendNotification(request);
@@ -60,8 +64,9 @@ public class NotificationController {
     }
 
     // 사용자가 알림을 읽었을 때 status 값을 변경하기 위한 API
+    @Operation(summary = "전송된 알림의 상태를 변경시키는 API 입니다.", description = "읽지 않은 알림에 대하여 읽음 상태로 변경 시킬 수 있습니다.")
     @PostMapping("/read")
-    public ResponseEntity<ApiResponse<?>> readNotification(@RequestParam("notificationId") Long notificationId) throws Exception{
+    public ResponseEntity<ApiResponse<?>> readNotification(@RequestParam("notificationId") Long notificationId) {
         notificationService.readNotification(notificationId);
         return ResponseEntity.ok(ApiResponse.createSuccessWithNoData());
     }

--- a/src/main/java/com/example/earthtalk/controller/NotificationController.java
+++ b/src/main/java/com/example/earthtalk/controller/NotificationController.java
@@ -5,7 +5,6 @@ import com.example.earthtalk.domain.notification.dto.request.SendNotificationReq
 import com.example.earthtalk.domain.notification.dto.response.NotificationListResponse;
 import com.example.earthtalk.domain.notification.service.NotificationService;
 import com.example.earthtalk.global.response.ApiResponse;
-import com.google.protobuf.Api;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -19,21 +18,51 @@ public class NotificationController {
 
     private final NotificationService notificationService;
 
+    // 접속중인 사용자의 알림을 조회하기 위한 API.
     @GetMapping("")
     public ResponseEntity<ApiResponse<List<NotificationListResponse>>> getNotificationList(@RequestParam("userId") Long userId) {
         List<NotificationListResponse> responses = notificationService.getNotifications(userId);
         return ResponseEntity.ok(ApiResponse.createSuccess(responses));
     }
 
+    // FE 에서 전송한 토큰값을 저장하기 위한 API.
     @PostMapping("/saveToken")
     public ResponseEntity<ApiResponse<?>> saveToken(@RequestBody SaveTokenRequest request) {
         notificationService.saveToken(request);
         return ResponseEntity.ok(ApiResponse.createSuccessWithNoData());
     }
 
+    /* FE 에서 알림에 관한 기능을 사용하기 위해 만든 API.
+     * BE 기준으로 Service 의 sendNotification 메서드만 호출해도 사용할 수 있습니다.
+     *
+     * 알림 전송 간단 가이드라인
+     * 1. SendNotificationRequest 설명 - 필드 값에는 userId, notificationType, typeId 가 들어갑니다.
+     *  1) userId - 알림을 받는 대상 id 에 관한 필드값입니다.
+     *  2) notificationType - 알림 유형에 관한 필드값입니다.
+     *      2-1 REPORT - 신고에 관한 유형입니다.
+     *      2-2 FOLLOW - 팔로우에 관한 유형입니다.
+     *      2-3 DEBATE - 토론방에 관한 유형입니다.
+     *      2-4 CHAT - 채팅방에 관한 유형입니다.
+     *      2-x ... - 필요 시 더 추가하여 사용하면 됩니다.
+     *  3) typeId - 알림유형에 관한 id 값입니다.
+     *      3-1 REPORT - 신고 ID 의 값입니다.
+     *      3-2 FOLLOW - 팔로우한 회원 ID 의 값입니다.
+     *      3-3 DEBATE - 토론방 ID 값입니다.
+     *      3-4 CHAT - 채팅방 ID 값입니다.
+     * 2. 알림 전송 로직
+     *   - Controller 의 send 는 FE 에서 한 행동에 대해 알림을 보내주기 위해 만든 API 입니다.
+     *   - 실질적인 로직은 Service 에 있습니다. (자세한 내용은 Service 에서 설명)
+     */
     @PostMapping("/send")
     public ResponseEntity<ApiResponse<String>> sendNotification(@RequestBody SendNotificationRequest request) throws Exception{
         String response = notificationService.sendNotification(request);
         return ResponseEntity.ok(ApiResponse.createSuccess(response));
+    }
+
+    // 사용자가 알림을 읽었을 때 status 값을 변경하기 위한 API
+    @PostMapping("/read")
+    public ResponseEntity<ApiResponse<?>> readNotification(@RequestParam("notificationId") Long notificationId) throws Exception{
+        notificationService.readNotification(notificationId);
+        return ResponseEntity.ok(ApiResponse.createSuccessWithNoData());
     }
 }

--- a/src/main/java/com/example/earthtalk/controller/NotificationController.java
+++ b/src/main/java/com/example/earthtalk/controller/NotificationController.java
@@ -1,0 +1,16 @@
+package com.example.earthtalk.controller;
+
+import com.example.earthtalk.domain.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+
+}

--- a/src/main/java/com/example/earthtalk/controller/NotificationController.java
+++ b/src/main/java/com/example/earthtalk/controller/NotificationController.java
@@ -1,9 +1,16 @@
 package com.example.earthtalk.controller;
 
+import com.example.earthtalk.domain.notification.dto.request.SaveTokenRequest;
+import com.example.earthtalk.domain.notification.dto.request.SendNotificationRequest;
+import com.example.earthtalk.domain.notification.dto.response.NotificationListResponse;
 import com.example.earthtalk.domain.notification.service.NotificationService;
+import com.example.earthtalk.global.response.ApiResponse;
+import com.google.protobuf.Api;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -12,5 +19,21 @@ public class NotificationController {
 
     private final NotificationService notificationService;
 
+    @GetMapping("")
+    public ResponseEntity<ApiResponse<List<NotificationListResponse>>> getNotificationList(@RequestParam("userId") Long userId) {
+        List<NotificationListResponse> responses = notificationService.getNotifications(userId);
+        return ResponseEntity.ok(ApiResponse.createSuccess(responses));
+    }
 
+    @PostMapping("/saveToken")
+    public ResponseEntity<ApiResponse<?>> saveToken(@RequestBody SaveTokenRequest request) {
+        notificationService.saveToken(request);
+        return ResponseEntity.ok(ApiResponse.createSuccessWithNoData());
+    }
+
+    @PostMapping("/send")
+    public ResponseEntity<ApiResponse<String>> sendNotification(@RequestBody SendNotificationRequest request) throws Exception{
+        String response = notificationService.sendNotification(request);
+        return ResponseEntity.ok(ApiResponse.createSuccess(response));
+    }
 }

--- a/src/main/java/com/example/earthtalk/domain/notification/dto/request/SaveNotificationRequest.java
+++ b/src/main/java/com/example/earthtalk/domain/notification/dto/request/SaveNotificationRequest.java
@@ -1,0 +1,19 @@
+package com.example.earthtalk.domain.notification.dto.request;
+
+import com.example.earthtalk.domain.notification.entity.Notification;
+import com.example.earthtalk.domain.notification.entity.NotificationType;
+import com.example.earthtalk.domain.notification.entity.StatusType;
+import com.example.earthtalk.domain.user.entity.User;
+
+public record SaveNotificationRequest (User user, NotificationType notificationType, Long typeId, String content){
+
+    public Notification toEntity() {
+        return Notification.builder()
+                .user(user)
+                .notificationType(notificationType)
+                .notificationTypeId(typeId)
+                .content(content)
+                .statusType(StatusType.UNREAD)
+                .build();
+    }
+}

--- a/src/main/java/com/example/earthtalk/domain/notification/dto/request/SaveTokenRequest.java
+++ b/src/main/java/com/example/earthtalk/domain/notification/dto/request/SaveTokenRequest.java
@@ -1,0 +1,22 @@
+package com.example.earthtalk.domain.notification.dto.request;
+
+import com.example.earthtalk.domain.user.entity.User;
+
+public record SaveTokenRequest(Long userId, String token) {
+
+    public User toEntity(User user) {
+        return User.builder()
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .introduction(user.getIntroduction())
+                .profileUrl(user.getProfileUrl())
+                .winNumber(user.getWinNumber())
+                .drawNumber(user.getDrawNumber())
+                .defeatNumber(user.getDefeatNumber())
+                .role(user.getRole())
+                .socialType(user.getSocialType())
+                .socialId(user.getSocialId())
+                .FCMToken(token)
+                .build();
+    }
+}

--- a/src/main/java/com/example/earthtalk/domain/notification/dto/request/SendNotificationRequest.java
+++ b/src/main/java/com/example/earthtalk/domain/notification/dto/request/SendNotificationRequest.java
@@ -1,0 +1,7 @@
+package com.example.earthtalk.domain.notification.dto.request;
+
+import com.example.earthtalk.domain.notification.entity.NotificationType;
+
+public record SendNotificationRequest(Long userId, NotificationType notificationType, Long typeId) {
+
+}

--- a/src/main/java/com/example/earthtalk/domain/notification/dto/response/NotificationListResponse.java
+++ b/src/main/java/com/example/earthtalk/domain/notification/dto/response/NotificationListResponse.java
@@ -1,0 +1,27 @@
+package com.example.earthtalk.domain.notification.dto.response;
+
+import com.example.earthtalk.domain.notification.entity.Notification;
+import com.example.earthtalk.domain.notification.entity.NotificationType;
+import com.example.earthtalk.domain.notification.entity.StatusType;
+
+import java.time.LocalDateTime;
+
+public record NotificationListResponse(
+        NotificationType notificationType,
+        Long typeId,
+        String content,
+        StatusType statusType,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt) {
+
+    public static NotificationListResponse from(Notification notification) {
+        return new NotificationListResponse(
+                notification.getNotificationType(),
+                notification.getNotificationTypeId(),
+                notification.getContent(),
+                notification.getStatusType(),
+                notification.getCreatedAt(),
+                notification.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/earthtalk/domain/notification/entity/Notification.java
+++ b/src/main/java/com/example/earthtalk/domain/notification/entity/Notification.java
@@ -35,4 +35,8 @@ public class Notification extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private StatusType statusType;
+
+    public void read() {
+        this.statusType = StatusType.READ;
+    }
 }

--- a/src/main/java/com/example/earthtalk/domain/notification/entity/Notification.java
+++ b/src/main/java/com/example/earthtalk/domain/notification/entity/Notification.java
@@ -6,7 +6,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-@Entity(name = "Notifications")
+@Entity(name = "notifications")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder

--- a/src/main/java/com/example/earthtalk/domain/notification/entity/Notification.java
+++ b/src/main/java/com/example/earthtalk/domain/notification/entity/Notification.java
@@ -1,0 +1,38 @@
+package com.example.earthtalk.domain.notification.entity;
+
+import com.example.earthtalk.domain.user.entity.User;
+import com.example.earthtalk.global.baseTime.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity(name = "Notifications")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public class Notification extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationType notificationType;
+
+    @Column(nullable = false)
+    private Long  notificationTypeId;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private StatusType statusType;
+}

--- a/src/main/java/com/example/earthtalk/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/example/earthtalk/domain/notification/entity/NotificationType.java
@@ -1,0 +1,15 @@
+package com.example.earthtalk.domain.notification.entity;
+
+
+public enum NotificationType {
+    REPORT("신고"),
+    CHAT("채팅방"),
+    DEBATE("토론방"),
+    FOLLOW("팔로우");
+
+    private final String value;
+
+    NotificationType(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/com/example/earthtalk/domain/notification/entity/StatusType.java
+++ b/src/main/java/com/example/earthtalk/domain/notification/entity/StatusType.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 @Getter
 public enum StatusType {
-    SEND("보냄"),
+    UNREAD("안읽음"),
     READ("읽음");
 
     private final String value;

--- a/src/main/java/com/example/earthtalk/domain/notification/entity/StatusType.java
+++ b/src/main/java/com/example/earthtalk/domain/notification/entity/StatusType.java
@@ -1,0 +1,15 @@
+package com.example.earthtalk.domain.notification.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum StatusType {
+    SEND("보냄"),
+    READ("읽음");
+
+    private final String value;
+
+    StatusType(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/com/example/earthtalk/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/example/earthtalk/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,7 @@
+package com.example.earthtalk.domain.notification.repository;
+
+import com.example.earthtalk.domain.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/com/example/earthtalk/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/example/earthtalk/domain/notification/repository/NotificationRepository.java
@@ -1,7 +1,15 @@
 package com.example.earthtalk.domain.notification.repository;
 
 import com.example.earthtalk.domain.notification.entity.Notification;
+import com.example.earthtalk.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    @Query("SELECT n FROM notifications n WHERE n.user = :user")
+    List<Notification> getNotifications(@Param("user") User user);
 }

--- a/src/main/java/com/example/earthtalk/domain/notification/service/FirebaseService.java
+++ b/src/main/java/com/example/earthtalk/domain/notification/service/FirebaseService.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service;
 public class FirebaseService {
 
     // 푸시 알림 전송 메서드
-    public String sendPushNotification(String token, String content) throws Exception {
+    public String pushNotification(String token, String content) throws Exception {
         // firebase 기반 notification 객체 생성
         Notification notification = Notification.builder()
                 .setTitle("알림")

--- a/src/main/java/com/example/earthtalk/domain/notification/service/FirebaseService.java
+++ b/src/main/java/com/example/earthtalk/domain/notification/service/FirebaseService.java
@@ -1,0 +1,29 @@
+package com.example.earthtalk.domain.notification.service;
+
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FirebaseService {
+
+    // 푸시 알림 전송 메서드
+    public String sendPushNotification(String token, String content) throws Exception {
+        // firebase 기반 notification 객체 생성
+        Notification notification = Notification.builder()
+                .setTitle("알림")
+                .setBody(content)
+                .build();
+
+        // notification 객체와 token 값을 이용하여 message 생성
+        Message message = Message.builder()
+                .setToken(token)
+                .setNotification(notification)
+                .build();
+
+        // 알림 전송
+        return FirebaseMessaging.getInstance().send(message);
+    }
+}

--- a/src/main/java/com/example/earthtalk/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/example/earthtalk/domain/notification/service/NotificationService.java
@@ -1,9 +1,81 @@
 package com.example.earthtalk.domain.notification.service;
 
+import com.example.earthtalk.domain.notification.dto.request.SaveTokenRequest;
+import com.example.earthtalk.domain.notification.dto.request.SendNotificationRequest;
+import com.example.earthtalk.domain.notification.dto.response.NotificationListResponse;
+import com.example.earthtalk.domain.notification.entity.Notification;
+import com.example.earthtalk.domain.notification.entity.NotificationType;
+import com.example.earthtalk.domain.notification.repository.NotificationRepository;
+import com.example.earthtalk.domain.report.entity.Report;
+import com.example.earthtalk.domain.report.repository.ReportRepository;
+import com.example.earthtalk.domain.user.entity.User;
+import com.example.earthtalk.domain.user.repository.UserRepository;
+import com.example.earthtalk.global.exception.ErrorCode;
+import com.example.earthtalk.global.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Service
+@RequiredArgsConstructor
 public class NotificationService {
 
+    private final NotificationRepository notificationRepository;
+    private final UserRepository userRepository;
+    private final FirebaseService firebaseService;
+    private final ReportRepository reportRepository;
 
+    public List<NotificationListResponse> getNotifications(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+
+        List<Notification> notifications = notificationRepository.getNotifications(user);
+        List<NotificationListResponse> responses = new ArrayList<>();
+        for (Notification notification : notifications) {
+            NotificationListResponse response = NotificationListResponse.from(notification);
+            responses.add(response);
+        }
+        return responses;
+    }
+
+    public void saveToken(SaveTokenRequest request) {
+        User user = request.toEntity(userRepository.findById(request.userId()).orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND)));
+        userRepository.save(user);
+    }
+
+    public String sendNotification(SendNotificationRequest request) throws Exception {
+        User user = userRepository.findById(request.userId()).orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+        String token = user.getFCMToken();
+        String content = getContent(request);
+        return firebaseService.sendPushNotification(token, content);
+    }
+
+    public String getContent(SendNotificationRequest request) {
+        NotificationType type = request.notificationType();
+        StringBuilder sb = new StringBuilder();
+        if (type == NotificationType.FOLLOW) {
+            User user = userRepository.findById(request.typeId()).orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+            sb.append(user.getNickname());
+            sb.append("님이 당신을 팔로우했습니다.");
+        }
+
+        if (type == NotificationType.REPORT) {
+            Report report = reportRepository.findById(request.typeId()).orElseThrow(() -> new NotFoundException(ErrorCode.REPORT_NOT_FOUND));
+            sb.append(report.getReportType().getValue());
+            sb.append("(으)로 운영자에게 ");
+            sb.append(report.getResultType().getValue());
+            sb.append("을(를) 처분받았습니다.");
+        }
+
+        if (type == NotificationType.DEBATE) {
+            sb.append("참가 중인 토론방의 대기가 완료되었습니다.");
+        }
+
+        if (type == NotificationType.CHAT) {
+            sb.append("참관 중인 토론방이 곧 시작합니다.");
+        }
+
+        return sb.toString();
+    }
 }

--- a/src/main/java/com/example/earthtalk/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/example/earthtalk/domain/notification/service/NotificationService.java
@@ -28,6 +28,10 @@ public class NotificationService {
     private final FirebaseService firebaseService;
     private final ReportRepository reportRepository;
 
+    private static final String FOLLOW_MESSAGE = "%s님이 당신을 팔로우했습니다.";
+    private static final String REPORT_MESSAGE = "%s(으)로 운영자에게 %s을(를) 처분받았습니다.";
+    private static final String DEBATE_MESSAGE = "참가 중인 토론방의 대기가 완료되었습니다.";
+
     // 접속중인 사용자의 id 값을 전달해주면 그와 관련된 알림을 조회하여 반환합니다.
     public List<NotificationListResponse> getNotifications(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
@@ -76,29 +80,21 @@ public class NotificationService {
     }
 
     // notiType 에 따라 content 를 가져오는 메서드.
-    public String getContent(SendNotificationRequest request) {
+    private String getContent(SendNotificationRequest request) {
         NotificationType type = request.notificationType();
         StringBuilder sb = new StringBuilder();
         if (type == NotificationType.FOLLOW) {
             User user = userRepository.findById(request.typeId()).orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
-            sb.append(user.getNickname());
-            sb.append("님이 당신을 팔로우했습니다.");
+            return String.format(FOLLOW_MESSAGE, user.getNickname());
         }
 
         if (type == NotificationType.REPORT) {
             Report report = reportRepository.findById(request.typeId()).orElseThrow(() -> new NotFoundException(ErrorCode.REPORT_NOT_FOUND));
-            sb.append(report.getReportType().getValue());
-            sb.append("(으)로 운영자에게 ");
-            sb.append(report.getResultType().getValue());
-            sb.append("을(를) 처분받았습니다.");
+            return String.format(REPORT_MESSAGE, report.getReportType().getValue(), report.getResultType().getValue());
         }
 
-        if (type == NotificationType.DEBATE) {
+        if (type == NotificationType.DEBATE || type == NotificationType.CHAT) {
             sb.append("참가 중인 토론방의 대기가 완료되었습니다.");
-        }
-
-        if (type == NotificationType.CHAT) {
-            sb.append("참관 중인 토론방이 곧 시작합니다.");
         }
 
         return sb.toString();

--- a/src/main/java/com/example/earthtalk/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/example/earthtalk/domain/notification/service/NotificationService.java
@@ -1,0 +1,9 @@
+package com.example.earthtalk.domain.notification.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class NotificationService {
+
+
+}

--- a/src/main/java/com/example/earthtalk/domain/report/dto/request/InsertReportRequest.java
+++ b/src/main/java/com/example/earthtalk/domain/report/dto/request/InsertReportRequest.java
@@ -9,7 +9,6 @@ public record InsertReportRequest(
         User user,
         User targetUser,
         Long targetRoomId,
-        Long targetId,
         TargetType targetType,
         String content,
         ReportType reportType
@@ -20,17 +19,9 @@ public record InsertReportRequest(
                 .user(user)
                 .targetUser(targetUser)
                 .targetRoomId(targetRoomId)
-                .targetId(getTargetId())
                 .targetType(targetType)
                 .content(content)
                 .reportType(reportType)
                 .build();
-    }
-
-    public Long getTargetId() {
-        if (targetType == TargetType.PROFILE) {
-            return null;
-        }
-        return targetId;
     }
 }

--- a/src/main/java/com/example/earthtalk/domain/report/dto/request/SearchReportRequest.java
+++ b/src/main/java/com/example/earthtalk/domain/report/dto/request/SearchReportRequest.java
@@ -1,0 +1,7 @@
+package com.example.earthtalk.domain.report.dto.request;
+
+import com.example.earthtalk.domain.report.entity.ReportType;
+import com.example.earthtalk.domain.report.entity.ResultType;
+
+public record SearchReportRequest(String q, ReportType type, ResultType result) {
+}

--- a/src/main/java/com/example/earthtalk/domain/report/dto/response/ReportDetailResponse.java
+++ b/src/main/java/com/example/earthtalk/domain/report/dto/response/ReportDetailResponse.java
@@ -17,17 +17,16 @@ public record ReportDetailResponse(
         String nickname,
         TargetType targetType,
         Long targetRoomId,
-        Long targetId,
+        Long targetUserId,
         String targetNickname,
-        String targetContent,
         String content,
-        ReportType reportType,
-        ResultType reportResult,
+        String reportType,
+        String reportResult,
         String reportContent,
         LocalDateTime createdAt
 ) {
 
-    public static ReportDetailResponse from(Report report, String targetContent) {
+    public static ReportDetailResponse from(Report report) {
         return new ReportDetailResponse(
                 report.getId(),
                 report.getUser().getNickname(),
@@ -35,10 +34,9 @@ public record ReportDetailResponse(
                 report.getTargetRoomId(),
                 report.getTargetUser().getId(),
                 report.getTargetUser().getNickname(),
-                targetContent,
                 report.getContent(),
-                report.getReportType(),
-                report.getResultType(),
+                report.getReportType().getValue(),
+                Report.getStringByResultType(report.getResultType()),
                 report.getReportContent(),
                 report.getCreatedAt()
         );

--- a/src/main/java/com/example/earthtalk/domain/report/dto/response/ReportListResponse.java
+++ b/src/main/java/com/example/earthtalk/domain/report/dto/response/ReportListResponse.java
@@ -10,8 +10,8 @@ public record ReportListResponse(
         Long id,
         String nickname,
         String targetNickname,
-        ReportType reportType,
-        ResultType reportResult,
+        String reportType,
+        String reportResult,
         String status,
         LocalDateTime createdAt)
 {
@@ -19,15 +19,15 @@ public record ReportListResponse(
         return new ReportListResponse(report.getId(),
                 report.getUser().getNickname(),
                 report.getTargetUser().getNickname(),
-                report.getReportType(),
-                report.getResultType(),
+                report.getReportType().getValue(),
+                Report.getStringByResultType(report.getResultType()),
                 ReportListResponse.getStatus(report.getResultType()),
                 report.getCreatedAt());
     }
 
     public static String getStatus(ResultType resultType) {
         if(resultType == ResultType.UNKNOWN) {
-            return "미처리";
+            return resultType.getValue();
         } else {
             return "처리 완료";
         }

--- a/src/main/java/com/example/earthtalk/domain/report/entity/Report.java
+++ b/src/main/java/com/example/earthtalk/domain/report/entity/Report.java
@@ -41,10 +41,7 @@ public class Report extends BaseTimeEntity {
     @JoinColumn(name = "target_user_id", nullable = false)
     private User targetUser; // 신고된 회원
 
-    @Column(nullable = false)
     private Long targetRoomId; // 신고된 방 id
-
-    private Long targetId;  // 신고된 대상 ID (채팅)
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -59,6 +56,8 @@ public class Report extends BaseTimeEntity {
 
     private String reportContent; // 신고 처리한 내용
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private ResultType resultType; // 신고 처리 유형
 
     private LocalDateTime reportedAt; // 신고 처리 날짜
@@ -66,7 +65,7 @@ public class Report extends BaseTimeEntity {
     public void updateReport(UpdateReportRequest request) {
         if(request == null) {
             this.reportContent = null;
-            this.resultType = null;
+            this.resultType = ResultType.UNKNOWN;
             this.reportedAt = null;
 
         } else {
@@ -75,5 +74,12 @@ public class Report extends BaseTimeEntity {
             this.resultType = updateReport.getResultType();
             this.reportedAt = LocalDateTime.now();
         }
+    }
+
+    public static String getStringByResultType(ResultType resultType) {
+        if(resultType == null) {
+            return null;
+        }
+        return resultType.getValue();
     }
 }

--- a/src/main/java/com/example/earthtalk/domain/report/entity/ReportType.java
+++ b/src/main/java/com/example/earthtalk/domain/report/entity/ReportType.java
@@ -4,12 +4,12 @@ import lombok.Getter;
 
 @Getter
 public enum ReportType {
-    OBSCENITY("선정성"),
-    SPAM("스팸"),
-    CUSS("욕설"),
+    OBSCENITY("음란성/선정성"),
+    SPAM("스팸 및 광고"),
+    CUSS("욕설/인신공격"),
     FLOODING("도배"),
-    LEAKAGE("유출"),
-    DODGE("탈주");
+    LEAKAGE("개인정보 유출"),
+    DODGE("사유없는 탈주");
 
     private final String value;
 

--- a/src/main/java/com/example/earthtalk/domain/report/entity/TargetType.java
+++ b/src/main/java/com/example/earthtalk/domain/report/entity/TargetType.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 @Getter
 public enum TargetType {
     CHAT("채팅방"), // 실시간 채팅 신고
-    DEBATE("토론방"), // 토론방 신고
     PROFILE("프로필"); // 유저 직접 신고
 
     private final String value;

--- a/src/main/java/com/example/earthtalk/domain/report/service/ReportService.java
+++ b/src/main/java/com/example/earthtalk/domain/report/service/ReportService.java
@@ -61,8 +61,7 @@ public class ReportService {
     // 하나의 신고에 대한 상세 조회하는 메서드
     public ReportDetailResponse getReportById(Long id) {
         Report report = reportRepository.findById(id).orElseThrow(() -> new NotFoundException(ErrorCode.REPORT_NOT_FOUND));
-        String reportContent = getTargetContent(report);
-        return ReportDetailResponse.from(report, reportContent);
+        return ReportDetailResponse.from(report);
     }
 
     // 신고를 처리하는 메서드
@@ -77,21 +76,5 @@ public class ReportService {
         Report report = reportRepository.findById(id).orElseThrow(() -> new NotFoundException(ErrorCode.REPORT_NOT_FOUND));
         report.updateReport(null);
         return reportRepository.save(report).getId();
-    }
-
-
-    // 신고된 타입 유형에따라 신고된 내용을 조회하는 메서드
-    String getTargetContent(Report report) {
-        if(report.getTargetType() == TargetType.CHAT) {
-            ObserverChat observerChat = observerChatRepository.findById(report.getId()).orElseThrow(() -> new NotFoundException(ErrorCode.CHAT_NOT_FOUND));
-            return observerChat.getContent();
-        }
-
-        if(report.getTargetType() == TargetType.DEBATE) {
-            DebateChat debateChat = debateChatRepository.findById(report.getId()).orElseThrow(() -> new NotFoundException(ErrorCode.CHAT_NOT_FOUND));
-            return debateChat.getContent();
-        }
-
-        return null;
     }
 }

--- a/src/main/java/com/example/earthtalk/domain/report/service/ReportService.java
+++ b/src/main/java/com/example/earthtalk/domain/report/service/ReportService.java
@@ -4,6 +4,9 @@ import com.example.earthtalk.domain.chat.ObserverChat;
 import com.example.earthtalk.domain.chat.repository.ObserverChatRepository;
 import com.example.earthtalk.domain.debate.entity.DebateChat;
 import com.example.earthtalk.domain.debate.repository.DebateChatRepository;
+import com.example.earthtalk.domain.notification.dto.request.SendNotificationRequest;
+import com.example.earthtalk.domain.notification.entity.NotificationType;
+import com.example.earthtalk.domain.notification.service.NotificationService;
 import com.example.earthtalk.domain.report.dto.request.InsertReportRequest;
 import com.example.earthtalk.domain.report.dto.request.UpdateReportRequest;
 import com.example.earthtalk.domain.report.dto.response.ReportDetailResponse;
@@ -31,8 +34,7 @@ import java.util.List;
 public class ReportService {
 
     private final ReportRepository reportRepository;
-    private final ObserverChatRepository observerChatRepository;
-    private final DebateChatRepository debateChatRepository;
+    private final NotificationService notificationService;
 
     // 신고하는 로직 간단하게 구현해놨습니다. 예외처리 따로 안되어있어요.
     // 각 위치에서 신고에 대한 기능 만들 때 예외 처리 해야합니다.
@@ -64,10 +66,12 @@ public class ReportService {
         return ReportDetailResponse.from(report);
     }
 
-    // 신고를 처리하는 메서드
-    public Long updateReport(Long id, UpdateReportRequest request) {
+    // 신고를 처리하는 메서드 - 알림 추가
+    public Long updateReport(Long id, UpdateReportRequest request) throws Exception {
         Report report = reportRepository.findById(id).orElseThrow(() -> new NotFoundException(ErrorCode.REPORT_NOT_FOUND));
         report.updateReport(request);
+        SendNotificationRequest sendNotificationRequest = new SendNotificationRequest(report.getTargetUser().getId(), NotificationType.REPORT, report.getTargetRoomId());
+        notificationService.sendNotification(sendNotificationRequest);
         return reportRepository.save(report).getId();
     }
 

--- a/src/main/java/com/example/earthtalk/domain/report/service/ReportService.java
+++ b/src/main/java/com/example/earthtalk/domain/report/service/ReportService.java
@@ -71,7 +71,7 @@ public class ReportService {
         Report report = reportRepository.findById(id).orElseThrow(() -> new NotFoundException(ErrorCode.REPORT_NOT_FOUND));
         report.updateReport(request);
         SendNotificationRequest sendNotificationRequest = new SendNotificationRequest(report.getTargetUser().getId(), NotificationType.REPORT, report.getTargetRoomId());
-        notificationService.sendNotification(sendNotificationRequest);
+        // notificationService.sendNotification(sendNotificationRequest);
         return reportRepository.save(report).getId();
     }
 

--- a/src/main/java/com/example/earthtalk/domain/user/entity/User.java
+++ b/src/main/java/com/example/earthtalk/domain/user/entity/User.java
@@ -55,10 +55,12 @@ public class User extends BaseTimeEntity {
 
     private String socialId; // 로그인한 소셜 타입 식별값
 
+    private String FCMToken; // 알림을 위한 FCM 토큰
+
     @Builder
     public User(String email, String nickname, String introduction, String profileUrl,
         Long winNumber, Long drawNumber, Long defeatNumber, Role role, SocialType socialType,
-        String socialId) {
+        String socialId, String FCMToken) {
         this.email = email;
         this.nickname = nickname;
         this.introduction = introduction;
@@ -69,5 +71,6 @@ public class User extends BaseTimeEntity {
         this.role = role;
         this.socialType = socialType;
         this.socialId = socialId;
+        this.FCMToken = FCMToken;
     }
 }

--- a/src/test/java/com/example/earthtalk/domain/debate/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/example/earthtalk/domain/debate/controller/ChatRoomControllerTest.java
@@ -2,8 +2,7 @@ package com.example.earthtalk.domain.debate.controller;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import com.example.earthtalk.domain.debate.dto.CreateDebateRoomRequest;
 import com.example.earthtalk.domain.debate.service.ChatRoomService;
@@ -65,6 +64,6 @@ public class ChatRoomControllerTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isOk())
-			.andExpect(content().string(expectedRoomId));
+				.andExpect(jsonPath("$.data").value(expectedRoomId));
 	}
 }

--- a/src/test/java/com/example/earthtalk/domain/debate/service/DebateManagementServiceTest.java
+++ b/src/test/java/com/example/earthtalk/domain/debate/service/DebateManagementServiceTest.java
@@ -91,7 +91,7 @@ public class DebateManagementServiceTest {
 		// Debate 엔티티에서는 description 필드에 채팅방의 부제(Subtitle)를 사용했다고 가정
 		assertEquals("Test Subtitle", savedDebate.getDescription());
 		assertEquals(MemberNumberType.T2, savedDebate.getMember());
-		assertEquals("아시아", savedDebate.getContinent().getValue());
+		assertEquals("아시아/호주", savedDebate.getContinent().getValue());
 		assertEquals("칼럼", savedDebate.getCategory().getValue());
 		assertEquals(5, savedDebate.getTime().getValue());
 		assertEquals(RoomType.DEBATE, savedDebate.getStatus());


### PR DESCRIPTION
## 📄 요약 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
알림 기능 구현 및 가이드라인 작성

## 🙋🏻 More <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
1. 알림 조회 API - userId 의 값을 통해 해당하는 유저의 알림 관련 리스트를 불러옵니다. ( limit 이나 페이지네이션 기능을 넣을까 고민했지만 FE 와 아직 얘기되지 않은 부분이므로 일단 전체 조회로 진행하고 추후에 FE 와 얘기하여 수정예정입니다.)

2. 토큰 저장 API - userId 값과 토큰 값을 통해 user 테이블에 null 값을 허용하는 새로 만들어진 FCMToken 이라는 칼럼에 저장하게 했습니다. (이 토큰은 디바이스 토큰값으로 토큰에 해당하는 디바이스에 알림을 전송합니다. -> 추후에 테이블을 분리하여 하나의 디바이스가 아닌 여러개의 디바이스에 해당하는 토큰값을 저장해 볼 생각입니다.)

3. 알림 전송 API - 실질적인 알림 전송은 service 에서 진행하지만 임의적으로 알림을 발송시키고 싶을 때 사용할 수 있도록 만들었습니다.

4. 알림 읽음 API - 전송된 알림을 사용자가 읽었을 때 상태를 변경시킵니다.

5. 신고에 관하여 신고처리가 되면 해당하는 user 에게 알림이 전송되도록 로직 작성해놨습니다.

6. AdminController 와 NotificationController 의 API 의 설명을 적어놨습니다. (swagger 에서 활용)
다른 분들도 알림에 대해 활용할 수 있도록 가이드라인 및 로직 작성해놨습니다.

## ✅ 피드백 반영사항 & 궁금한 점  <!-- 지난 코드리뷰에서 고친 사항 또는 궁금한 점 적어주세요 -->
현재 테스트를 진행하지 못한 코드입니다.
1. 제가 임의적으로 FCM 토큰에 대해서 받아올 수 없기에 알림 기능에 관한 테스트는 FE 와 연결이 되면 진행가능합니다..
2. swagger 에서 403 에러를 통해 테스트 진행이 안됩니다.
3. postman 을 활용하려고 했지만 swagger 접속 시 보여지는 html 에 관한 정보만 반환되기에 테스트를 진행하지 못했습니다.

-> user 와 security 의 작업이 완료되면 토큰값이 필요한 알림전송 외에는 다시 test 진행 및 오류 수정할 예정입니다.

여담)
stash 를 하지않고 develop 브랜치에 pull 을 받으러 갔다가 작성한 코드를 날려서 다시 새로 작성하느라 시간이 조금 걸렸네요..
수습하느라 불필요한 commit 이 많아서 기능 및 작성 사항에 대해서 적어뒀습니다.