### PR TITLE
fix: debate.getNews가 null 허용이기 때문에 null 처리를 해줌으로써 빌드 에러 핸들링

### DIFF
--- a/src/main/java/com/example/earthtalk/domain/debate/controller/DebateRoomController.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/controller/DebateRoomController.java
@@ -154,7 +154,7 @@ public class DebateRoomController {
 			.memberNumberType(debate.getMember().getValue())
 			.categoryType(debate.getCategory())
 			.continentType(debate.getContinent())
-			.newsUrl(debate.getNews().getLink())
+			.newsUrl(debate.getNews() != null ? debate.getNews().getLink() : null)
 			.status(debate.getStatus())
 			.timeType(debate.getTime().getValue())
 			.speakCountType(debate.getSpeakCount().getValue());


### PR DESCRIPTION
## 📄 요약 debate 저장 중에 nullPointerException 처리

> closed #97

## 🙋🏻 More <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

## ✅ 피드백 반영사항 & 궁금한 점  <!-- 지난 코드리뷰에서 고친 사항 또는 궁금한 점 적어주세요 -->
