### PR TITLE
fix: 프로필 이미지 수정 시 다른 항목에 일괄 null 삽입되는 에러 수정

### DIFF
--- a/src/main/java/com/example/earthtalk/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/earthtalk/domain/user/repository/UserRepository.java
@@ -17,7 +17,11 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
 
     @Modifying
     @Transactional
-    @Query("UPDATE users u SET u.nickname = :nickname, u.introduction = :introduction, u.profileUrl = :profile WHERE u.id = :userId")
+    @Query("UPDATE users u " +
+        "SET u.nickname = COALESCE(:nickname, u.nickname), " +
+        "    u.introduction = COALESCE(:introduction, u.introduction), " +
+        "    u.profileUrl = COALESCE(:profile, u.profileUrl) " +
+        "WHERE u.id = :userId")
     void updateUserById(@Param("nickname") String nickname,
         @Param("introduction") String introduction,
         @Param("profile") String profile,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,6 @@
 spring:
-  config:
-    import:
-      - classpath:/config/application-prod.yml
   profiles:
-    active: prod
+    active: dev
     group:
-      prod: "prod"
-      dev:  "dev"
+      "prod": "prod"
+      "dev":  "dev"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,9 @@
 spring:
+  config:
+    import:
+      - classpath:/config/application-prod.yml
   profiles:
-    active: dev
+    active: prod
     group:
-      "prod": "prod"
-      "dev":  "dev"
+      prod: "prod"
+      dev:  "dev"


### PR DESCRIPTION
## 📄 요약 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
<!-- 이슈 닫아주세요 -->
> closed #88 

프로필 수정시 프로필 사진이나 닉네임, 설명을 모두 개별적으로 수정할 수 있도록 에러 수정
