### PR TITLE
fix: fetch type Lazy에 걸리지 않도록 dto를 생성하여 데이터를 제공

### DIFF
--- a/src/main/java/com/example/earthtalk/domain/debate/dto/CreateDebateRoomRequest.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/dto/CreateDebateRoomRequest.java
@@ -10,11 +10,12 @@ import com.example.earthtalk.domain.news.entity.News;
 import com.example.earthtalk.domain.news.entity.TimeType;
 import com.example.earthtalk.global.constant.ContinentType;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
-@Setter
+@Builder
 public class CreateDebateRoomRequest {
 	private Long newsId;
 

--- a/src/main/java/com/example/earthtalk/domain/debate/dto/DebateMetaDataResponse.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/dto/DebateMetaDataResponse.java
@@ -2,9 +2,6 @@ package com.example.earthtalk.domain.debate.dto;
 
 import java.util.Set;
 
-import com.example.earthtalk.domain.debate.entity.Debate;
-import com.example.earthtalk.domain.user.entity.User;
-
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -13,9 +10,9 @@ import lombok.RequiredArgsConstructor;
 @Builder
 @RequiredArgsConstructor
 public class DebateMetaDataResponse {
-	private final Debate debate;
+	private final CreateDebateRoomRequest debateRoomRequest;
 	private final Long currentCount;
 	private final Long maxCount;
-	private final Set<User> proUsers;
-	private final Set<User> conUsers;
+	private final Set<DebateUserResponse> proUsers;
+	private final Set<DebateUserResponse> conUsers;
 }

--- a/src/main/java/com/example/earthtalk/domain/debate/dto/DebateRoomResponse.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/dto/DebateRoomResponse.java
@@ -1,8 +1,10 @@
 package com.example.earthtalk.domain.debate.dto;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.example.earthtalk.domain.debate.entity.CategoryType;
+import com.example.earthtalk.domain.debate.entity.Debate;
 import com.example.earthtalk.domain.debate.entity.RoomType;
 import com.example.earthtalk.global.constant.ContinentType;
 

--- a/src/main/java/com/example/earthtalk/domain/debate/dto/DebateUserResponse.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/dto/DebateUserResponse.java
@@ -1,6 +1,7 @@
 package com.example.earthtalk.domain.debate.dto;
 
 import com.example.earthtalk.domain.debate.entity.FlagType;
+import com.example.earthtalk.domain.user.entity.User;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -25,4 +26,17 @@ public class DebateUserResponse {
 	private Long drawNumber = 0L;
 
 	private Long defeatNumber = 0L;
+
+	public static DebateUserResponse fromEntity(User user) {
+		return DebateUserResponse.builder()
+			.id(user.getId())
+			.email(user.getEmail())
+			.nickname(user.getNickname())
+			.introduction(user.getIntroduction())
+			.profileUrl(user.getProfileUrl())
+			.winNumber(user.getWinNumber())
+			.drawNumber(user.getDrawNumber())
+			.defeatNumber(user.getDefeatNumber())
+			.build();
+	}
 }

--- a/src/main/java/com/example/earthtalk/domain/debate/service/DebateMetaDataService.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/service/DebateMetaDataService.java
@@ -2,7 +2,6 @@ package com.example.earthtalk.domain.debate.service;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -10,7 +9,9 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
+import com.example.earthtalk.domain.debate.dto.CreateDebateRoomRequest;
 import com.example.earthtalk.domain.debate.dto.DebateMetaDataResponse;
+import com.example.earthtalk.domain.debate.dto.DebateUserResponse;
 import com.example.earthtalk.domain.debate.entity.Debate;
 import com.example.earthtalk.domain.debate.repository.DebateRepository;
 import com.example.earthtalk.domain.debate.store.DebateRoomStore;
@@ -83,17 +84,40 @@ public class DebateMetaDataService {
 			Set<User> proUsers = fetchUsersByNames(debateUserStore.getProUsers(roomId));
 			Set<User> conUsers = fetchUsersByNames(debateUserStore.getConUsers(roomId));
 
+			// CreateDebateRoomRequest를 builder를 통해 생성
+			CreateDebateRoomRequest debateRoomRequest = CreateDebateRoomRequest.builder()
+				.newsId(debate.getNews() != null ? debate.getNews().getId() : null)
+				.title(debate.getTitle())
+				.newsUrl(debate.getNews() != null ? debate.getNews().getLink() : "")
+				.description(debate.getDescription())
+				.memberNumber(debate.getMember())
+				.continent(debate.getContinent())
+				.category(debate.getCategory())
+				.time(debate.getTime())
+				.speakCount(debate.getSpeakCount())
+				.resultEnabled(debate.isResultEnabled())
+				.build();
+
+			Set<DebateUserResponse> proUserResponses = proUsers.stream()
+				.map(DebateUserResponse::fromEntity)
+				.collect(Collectors.toSet());
+			Set<DebateUserResponse> conUserResponses = conUsers.stream()
+				.map(DebateUserResponse::fromEntity)
+				.collect(Collectors.toSet());
+
 			DebateMetaDataResponse response = DebateMetaDataResponse.builder()
-				.debate(debate)
+				.debateRoomRequest(debateRoomRequest)
 				.currentCount(currentCount)
 				.maxCount(maxCount)
-				.proUsers(proUsers)
-				.conUsers(conUsers)
+				.proUsers(proUserResponses)
+				.conUsers(conUserResponses)
 				.build();
 			responses.add(response);
 		}
 		return responses;
 	}
+
+
 
 	private Set<User> fetchUsersByNames(Collection<String> userNames) {
 		return userNames.stream()


### PR DESCRIPTION
## 📄 요약 fetchType lazy에 걸리지 않도록 dto 생성하는 로직 추가
> closed #133 

