### PR TITLE
fix: fetch type Lazy 문제를 해결하기 위해 news를 제거한 dto, DebateMetaDateRespons…

### DIFF
--- a/src/main/java/com/example/earthtalk/domain/debate/dto/DebateMetaDataResponse.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/dto/DebateMetaDataResponse.java
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 @Builder
 @RequiredArgsConstructor
 public class DebateMetaDataResponse {
-	private final CreateDebateRoomRequest debateRoomRequest;
+	private final DebateMetaDataRoomResponse debateMetaDataRoomResponse;
 	private final Long currentCount;
 	private final Long maxCount;
 	private final Set<DebateUserResponse> proUsers;

--- a/src/main/java/com/example/earthtalk/domain/debate/dto/DebateMetaDataRoomResponse.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/dto/DebateMetaDataRoomResponse.java
@@ -1,0 +1,39 @@
+package com.example.earthtalk.domain.debate.dto;
+
+import com.example.earthtalk.domain.debate.entity.CategoryType;
+import com.example.earthtalk.domain.debate.entity.Debate;
+import com.example.earthtalk.domain.debate.entity.SpeakCountType;
+import com.example.earthtalk.domain.news.entity.MemberNumberType;
+import com.example.earthtalk.domain.news.entity.News;
+import com.example.earthtalk.domain.news.entity.TimeType;
+import com.example.earthtalk.global.constant.ContinentType;
+import lombok.Builder;
+import lombok.Getter;
+import org.hibernate.Hibernate;
+
+@Getter
+@Builder
+public class DebateMetaDataRoomResponse {
+	private String title;
+	private String description;
+	private MemberNumberType memberNumber;
+	private ContinentType continent;
+	private CategoryType category;
+	private TimeType time;
+	private SpeakCountType speakCount;
+	private boolean resultEnabled;
+
+	public static DebateMetaDataRoomResponse fromEntity(Debate debate) {
+
+		return DebateMetaDataRoomResponse.builder()
+			.title(debate.getTitle())
+			.description(debate.getDescription())
+			.memberNumber(debate.getMember())
+			.continent(debate.getContinent())
+			.category(debate.getCategory())
+			.time(debate.getTime())
+			.speakCount(debate.getSpeakCount())
+			.resultEnabled(debate.isResultEnabled())
+			.build();
+	}
+}

--- a/src/main/java/com/example/earthtalk/domain/debate/service/DebateMetaDataService.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/service/DebateMetaDataService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 
 import com.example.earthtalk.domain.debate.dto.CreateDebateRoomRequest;
 import com.example.earthtalk.domain.debate.dto.DebateMetaDataResponse;
+import com.example.earthtalk.domain.debate.dto.DebateMetaDataRoomResponse;
 import com.example.earthtalk.domain.debate.dto.DebateUserResponse;
 import com.example.earthtalk.domain.debate.entity.Debate;
 import com.example.earthtalk.domain.debate.repository.DebateRepository;
@@ -84,19 +85,7 @@ public class DebateMetaDataService {
 			Set<User> proUsers = fetchUsersByNames(debateUserStore.getProUsers(roomId));
 			Set<User> conUsers = fetchUsersByNames(debateUserStore.getConUsers(roomId));
 
-			// CreateDebateRoomRequest를 builder를 통해 생성
-			CreateDebateRoomRequest debateRoomRequest = CreateDebateRoomRequest.builder()
-				.newsId(debate.getNews() != null ? debate.getNews().getId() : null)
-				.title(debate.getTitle())
-				.newsUrl(debate.getNews() != null ? debate.getNews().getLink() : "")
-				.description(debate.getDescription())
-				.memberNumber(debate.getMember())
-				.continent(debate.getContinent())
-				.category(debate.getCategory())
-				.time(debate.getTime())
-				.speakCount(debate.getSpeakCount())
-				.resultEnabled(debate.isResultEnabled())
-				.build();
+			DebateMetaDataRoomResponse debateRoomResponse = DebateMetaDataRoomResponse.fromEntity(debate);
 
 			Set<DebateUserResponse> proUserResponses = proUsers.stream()
 				.map(DebateUserResponse::fromEntity)
@@ -106,7 +95,7 @@ public class DebateMetaDataService {
 				.collect(Collectors.toSet());
 
 			DebateMetaDataResponse response = DebateMetaDataResponse.builder()
-				.debateRoomRequest(debateRoomRequest)
+				.debateMetaDataRoomResponse(debateRoomResponse)
 				.currentCount(currentCount)
 				.maxCount(maxCount)
 				.proUsers(proUserResponses)


### PR DESCRIPTION
## 📄 요약 fetch type Lazy 문제를 해결하기 위해 news를 제거한 dto, DebateMetaDateResponse를 생성하여 해당 dto로 자료를 전송하도록 변경
<!-- 이슈 닫아주세요 -->
> closed #138 

