### PR TITLE
feat: 알림 조회 시 읽지 않은 알림의 개수도 반환

### DIFF
--- a/src/main/java/com/example/earthtalk/controller/NotificationController.java
+++ b/src/main/java/com/example/earthtalk/controller/NotificationController.java
@@ -6,6 +6,7 @@ import com.example.earthtalk.domain.notification.dto.request.SaveTokenRequest;
 import com.example.earthtalk.domain.notification.dto.request.SendNotificationRequest;
 import com.example.earthtalk.domain.notification.dto.response.CheckTokenResponse;
 import com.example.earthtalk.domain.notification.dto.response.NotificationListResponse;
+import com.example.earthtalk.domain.notification.dto.response.NotificationListResponseWithUnreadCount;
 import com.example.earthtalk.domain.notification.service.FcmTokenService;
 import com.example.earthtalk.domain.notification.service.NotificationService;
 import com.example.earthtalk.global.response.ApiResponse;
@@ -28,10 +29,10 @@ public class NotificationController {
     // 접속중인 사용자의 알림을 조회하기 위한 API.
     @Operation(summary = "알림 조회 API 입니다.", description = "userId 의 값을 받아 해당하는 알림들을 조회합니다.")
     @GetMapping("/{userId}")
-    public ResponseEntity<ApiResponse<Page<NotificationListResponse>>> getNotificationList(@PathVariable Long userId,
-                                                                                            @RequestParam(value = "page", required = false, defaultValue = "1") int page) {
-        Page<NotificationListResponse> responses = notificationService.getNotifications(userId, page);
-        return ResponseEntity.ok(ApiResponse.createSuccess(responses));
+    public ResponseEntity<ApiResponse<NotificationListResponseWithUnreadCount>> getNotificationList(@PathVariable Long userId,
+                                                                                                    @RequestParam(value = "page", required = false, defaultValue = "1") int page) {
+        NotificationListResponseWithUnreadCount response = notificationService.getNotifications(userId, page);
+        return ResponseEntity.ok(ApiResponse.createSuccess(response));
     }
 
     @Operation(summary = "FCM 토큰 조회 API 입니다.", description = "토큰 값과 userId 값을 통해 토큰값이 이미 존재하는지 확인합니다.")

--- a/src/main/java/com/example/earthtalk/domain/notification/dto/response/NotificationListResponseWithUnreadCount.java
+++ b/src/main/java/com/example/earthtalk/domain/notification/dto/response/NotificationListResponseWithUnreadCount.java
@@ -1,0 +1,9 @@
+package com.example.earthtalk.domain.notification.dto.response;
+
+import org.springframework.data.domain.Page;
+
+public record NotificationListResponseWithUnreadCount(
+        int unreadCount,
+        Page<NotificationListResponse> notifications
+) {
+}

--- a/src/main/java/com/example/earthtalk/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/example/earthtalk/domain/notification/repository/NotificationRepository.java
@@ -18,5 +18,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Query("UPDATE notifications n SET n.statusType = 'READ' WHERE n.user = :user")
     void markAllAsReadByUserId(@Param("user") User user);
 
+    @Query("SELECT COUNT(*) FROM notifications n WHERE n.user = :user AND n.statusType = 'UNREAD'")
+    int getCountUnread(@Param("user") User user);
+
     void deleteAllByUserId(Long id);
 }

--- a/src/main/java/com/example/earthtalk/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/example/earthtalk/domain/notification/service/NotificationService.java
@@ -7,6 +7,7 @@ import com.example.earthtalk.domain.notification.dto.request.SaveTokenRequest;
 import com.example.earthtalk.domain.notification.dto.request.SendNotificationRequest;
 import com.example.earthtalk.domain.notification.dto.response.CheckTokenResponse;
 import com.example.earthtalk.domain.notification.dto.response.NotificationListResponse;
+import com.example.earthtalk.domain.notification.dto.response.NotificationListResponseWithUnreadCount;
 import com.example.earthtalk.domain.notification.entity.Notification;
 import com.example.earthtalk.domain.notification.entity.NotificationType;
 import com.example.earthtalk.domain.notification.repository.NotificationRepository;
@@ -50,13 +51,18 @@ public class NotificationService {
     private static final String NOTIFICATION_STRING = "%d,%s,%d,%s,%s";
 
     // 접속중인 사용자의 id 값을 전달해주면 그와 관련된 알림을 조회하여 반환합니다.
-    public Page<NotificationListResponse> getNotifications(Long userId, int page) {
+    public NotificationListResponseWithUnreadCount getNotifications(Long userId, int page) {
         User user = userRepository.findById(userId).orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
 
         Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "id"));
         Page<Notification> notifications = notificationRepository.getNotifications(user, pageable);
 
-        return notifications.map(NotificationListResponse::from);
+        int unreadCount = notificationRepository.getCountUnread(user);
+
+        return new NotificationListResponseWithUnreadCount(
+                unreadCount,
+                notifications.map(NotificationListResponse::from)
+        );
     }
 
     public CheckTokenResponse checkToken(CheckTokenRequest request) {


### PR DESCRIPTION
## 📄 요약 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
<!-- 이슈 닫아주세요 -->
> closed #146 

## 🙋🏻 More <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
알림 조회 시 읽지 않은 알림의 count 를 포함해서 반환 -- FE 요청
  - 새로운 dto 를 만들어서 반환해야 하기 때문에 추가되었습니다.

## ✅ 피드백 반영사항 & 궁금한 점  <!-- 지난 코드리뷰에서 고친 사항 또는 궁금한 점 적어주세요 -->
