### PR TITLE
Feat/#153 debate

### DIFF
--- a/src/main/java/com/example/earthtalk/domain/debate/controller/DebateRoomController.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/controller/DebateRoomController.java
@@ -1,20 +1,14 @@
 package com.example.earthtalk.domain.debate.controller;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
+import com.example.earthtalk.domain.debate.entity.*;
+import com.example.earthtalk.domain.news.entity.TimeType;
+import com.example.earthtalk.global.constant.ContinentType;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,23 +16,11 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.earthtalk.domain.debate.dto.DebateRoomResponse;
-import com.example.earthtalk.domain.debate.dto.DebateUserResponse;
 import com.example.earthtalk.domain.debate.dto.VoteRequest;
 import com.example.earthtalk.domain.debate.dto.VoteResponse;
 import com.example.earthtalk.domain.debate.dto.WaitRoomResponse;
-import com.example.earthtalk.domain.debate.entity.Debate;
-import com.example.earthtalk.domain.debate.entity.DebateParticipants;
-import com.example.earthtalk.domain.debate.entity.FlagType;
-import com.example.earthtalk.domain.debate.entity.RoomType;
-import com.example.earthtalk.domain.debate.repository.DebateParticipantsRepository;
 import com.example.earthtalk.domain.debate.repository.DebateRepository;
 import com.example.earthtalk.domain.debate.service.DebateRoomService;
-import com.example.earthtalk.domain.debate.service.DebateUserService;
-import com.example.earthtalk.domain.debate.store.DebateUserStore;
-import com.example.earthtalk.domain.report.dto.request.InsertReportRequest;
-import com.example.earthtalk.domain.report.service.ReportService;
-import com.example.earthtalk.domain.user.entity.User;
-import com.example.earthtalk.domain.user.repository.UserRepository;
 import com.example.earthtalk.global.exception.ErrorCode;
 import com.example.earthtalk.global.response.ApiResponse;
 
@@ -54,12 +36,7 @@ import lombok.RequiredArgsConstructor;
 public class DebateRoomController {
 
 	private final DebateRepository debateRepository;
-	private final DebateParticipantsRepository debateParticipantsRepository;
-	private final UserRepository userRepository;
-	private final ReportService reportService;
 	private final DebateRoomService debateRoomService;
-	private final DebateUserService debateUserService;
-	private final DebateUserStore debateUserStore;
 
 	@Operation(summary = "토론방 상세 조회 API", description = "토론방의 UUID로 상세 정보를 조회합니다.")
 	@ApiResponses(value = {
@@ -67,7 +44,7 @@ public class DebateRoomController {
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 토론방을 찾을 수 없습니다.")
 	})
 	@GetMapping("/{uuid}")
-	public ResponseEntity<ApiResponse<Object>> getDebateRoom(
+	public ResponseEntity<ApiResponse<DebateRoomResponse>> getDebateRoom(
 		@PathVariable("uuid") String uuid
 	) {
 		UUID roomId = UUID.fromString(uuid);
@@ -78,14 +55,18 @@ public class DebateRoomController {
 		return ResponseEntity.ok().body(ApiResponse.createSuccess(response));
 	}
 
-	@GetMapping("/debateroom/finished")
-	public ResponseEntity<ApiResponse<Object>> getFinishedDebateRoom(
-		@RequestParam(defaultValue = "0") int page,
-		@RequestParam(defaultValue = "15") int size
+	@GetMapping("/debateRoom/finished")
+	public ResponseEntity<ApiResponse<Page<Debate>>> getFinishedDebateRoom(
+			@RequestParam(value = "q", required = false) String q,
+			@RequestParam(value = "continent", required = false) ContinentType continent,
+			@RequestParam(value = "category", required = false)CategoryType category,
+			@RequestParam(value = "time", required = false)TimeType time,
+			@RequestParam(value = "p", required = false, defaultValue = "1") int page,
+			@RequestParam(value = "sort", required = false, defaultValue = "recent") String sort
 	) {
-		Pageable pageable = PageRequest.of(page, size, Sort.by("id").descending());
-		Page<Debate> debates = debateRepository.findByStatus(RoomType.CLOSED, pageable);
-		return ResponseEntity.ok(ApiResponse.createSuccess(debates.isEmpty() ? null : debates));
+		page = page <= 1 ? 0 : page - 1;
+		Page<Debate> debates = debateRoomService.getFinishDebateRooms(q, continent, category, time, page, sort);
+		return ResponseEntity.ok(ApiResponse.createSuccess(debates));
 	}
 
 	@Operation(summary = "관전자 토론방 상세 조회 API", description = "토론방의 UUID로 관전자용 상세 정보를 조회합니다.")
@@ -94,7 +75,7 @@ public class DebateRoomController {
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 토론방을 찾을 수 없습니다.")
 	})
 	@GetMapping("/observer/{uuid}")
-	public ResponseEntity<ApiResponse<Object>> getObserverDebateRoom(
+	public ResponseEntity<ApiResponse<DebateRoomResponse>> getObserverDebateRoom(
 		@PathVariable("uuid") String uuid
 	) {
 		UUID roomId = UUID.fromString(uuid);
@@ -111,7 +92,7 @@ public class DebateRoomController {
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 토론방을 찾을 수 없습니다.")
 	})
 	@GetMapping("/waitroom/{uuid}")
-	public ResponseEntity<ApiResponse<Object>> getObserverWaitRoom(
+	public ResponseEntity<ApiResponse<WaitRoomResponse>> getObserverWaitRoom(
 		@PathVariable("uuid") String uuid
 	) {
 		UUID roomId = UUID.fromString(uuid);
@@ -132,7 +113,7 @@ public class DebateRoomController {
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 토론방을 찾을 수 없습니다."),
 	})
 	@PutMapping("/vote/{roomId}")
-	public ResponseEntity<ApiResponse<Object>> putVote(
+	public ResponseEntity<ApiResponse<Void>> putVote(
 		@PathVariable("roomId") String roomId,
 		@RequestBody VoteRequest request) {
 		Debate debate = debateRepository.findByUuid(UUID.fromString(roomId))
@@ -150,7 +131,7 @@ public class DebateRoomController {
 
 		debateRepository.save(debate);
 
-		return ResponseEntity.ok(ApiResponse.createSuccessWithNoData());
+		return ResponseEntity.ok(ApiResponse.createSuccess(null));
 
 	}
 
@@ -160,7 +141,7 @@ public class DebateRoomController {
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 토론방을 찾을 수 없습니다."),
 	})
 	@GetMapping("/vote/{roomId}")
-	public ResponseEntity<ApiResponse<Object>> getVote(
+	public ResponseEntity<ApiResponse<VoteResponse>> getVote(
 		@PathVariable("roomId") Long roomId
 	) {
 		Debate debate = debateRepository.findById(roomId)

--- a/src/main/java/com/example/earthtalk/domain/debate/controller/DebateRoomController.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/controller/DebateRoomController.java
@@ -3,6 +3,7 @@ package com.example.earthtalk.domain.debate.controller;
 import java.util.UUID;
 
 import com.example.earthtalk.domain.debate.entity.*;
+import com.example.earthtalk.domain.news.entity.MemberNumberType;
 import com.example.earthtalk.domain.news.entity.TimeType;
 import com.example.earthtalk.global.constant.ContinentType;
 import org.springframework.data.domain.Page;
@@ -60,12 +61,12 @@ public class DebateRoomController {
 			@RequestParam(value = "q", required = false) String q,
 			@RequestParam(value = "continent", required = false) ContinentType continent,
 			@RequestParam(value = "category", required = false)CategoryType category,
-			@RequestParam(value = "time", required = false)TimeType time,
+			@RequestParam(value = "member", required = false) MemberNumberType member,
 			@RequestParam(value = "p", required = false, defaultValue = "1") int page,
 			@RequestParam(value = "sort", required = false, defaultValue = "recent") String sort
 	) {
 		page = page <= 1 ? 0 : page - 1;
-		Page<Debate> debates = debateRoomService.getFinishDebateRooms(q, continent, category, time, page, sort);
+		Page<Debate> debates = debateRoomService.getFinishDebateRooms(q, continent, category, member, page, sort);
 		return ResponseEntity.ok(ApiResponse.createSuccess(debates));
 	}
 

--- a/src/main/java/com/example/earthtalk/domain/debate/repository/DebateRepository.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/repository/DebateRepository.java
@@ -1,17 +1,37 @@
 package com.example.earthtalk.domain.debate.repository;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.example.earthtalk.domain.debate.entity.CategoryType;
+import com.example.earthtalk.domain.news.entity.TimeType;
+import com.example.earthtalk.global.constant.ContinentType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.example.earthtalk.domain.debate.entity.Debate;
-import com.example.earthtalk.domain.debate.entity.RoomType;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface DebateRepository extends JpaRepository<Debate, Long> {
+
 	Optional<Debate> findByUuid(UUID uuid);
-	Page<Debate> findByStatus(RoomType status, Pageable pageable);
+
+	@Query("SELECT d FROM debates d "+
+			"WHERE (:query IS NULL OR d.title LIKE CONCAT('%', :query, '%')) AND " +
+			"(:continent IS NULL OR d.continent = :continent) AND " +
+			"(:category IS NULL OR d.category = :category) AND " +
+			"(:time IS NULL OR d.time = :time) AND " +
+			"d.status = 0" +
+			"ORDER BY CASE " +
+			"WHEN :sort = 'popular' THEN (d.agreeNumber + d.disagreeNumber + d.neutralNumber)" +
+			"ELSE d.updatedAt " +
+			"END DESC")
+	Page<Debate> findFinishDebatesByParams(@Param("query") String query,
+										   @Param("continent")ContinentType continent,
+										   @Param("category") CategoryType category,
+										   @Param("time") TimeType time,
+										   @Param("sort") String sort,
+										   Pageable pageable);
 }

--- a/src/main/java/com/example/earthtalk/domain/debate/repository/DebateRepository.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/repository/DebateRepository.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import com.example.earthtalk.domain.debate.entity.CategoryType;
+import com.example.earthtalk.domain.news.entity.MemberNumberType;
 import com.example.earthtalk.domain.news.entity.TimeType;
 import com.example.earthtalk.global.constant.ContinentType;
 import org.springframework.data.domain.Page;
@@ -22,7 +23,7 @@ public interface DebateRepository extends JpaRepository<Debate, Long> {
 			"WHERE (:query IS NULL OR d.title LIKE CONCAT('%', :query, '%')) AND " +
 			"(:continent IS NULL OR d.continent = :continent) AND " +
 			"(:category IS NULL OR d.category = :category) AND " +
-			"(:time IS NULL OR d.time = :time) AND " +
+			"(:member IS NULL OR d.member = :member) AND " +
 			"d.status = 0" +
 			"ORDER BY CASE " +
 			"WHEN :sort = 'popular' THEN (d.agreeNumber + d.disagreeNumber + d.neutralNumber)" +
@@ -31,7 +32,7 @@ public interface DebateRepository extends JpaRepository<Debate, Long> {
 	Page<Debate> findFinishDebatesByParams(@Param("query") String query,
 										   @Param("continent")ContinentType continent,
 										   @Param("category") CategoryType category,
-										   @Param("time") TimeType time,
+										   @Param("member") MemberNumberType member,
 										   @Param("sort") String sort,
 										   Pageable pageable);
 }

--- a/src/main/java/com/example/earthtalk/domain/debate/service/DebateRoomService.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/service/DebateRoomService.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import com.example.earthtalk.domain.debate.entity.*;
+import com.example.earthtalk.domain.news.entity.MemberNumberType;
 import com.example.earthtalk.domain.news.entity.TimeType;
 import com.example.earthtalk.global.constant.ContinentType;
 import jakarta.transaction.Transactional;
@@ -140,9 +141,9 @@ public class DebateRoomService {
 			.orElseThrow(() -> new IllegalArgumentException(ErrorCode.DEBATEROOM_NOT_FOUND.getMessage()));
 	}
 
-	public Page<Debate> getFinishDebateRooms(String query, ContinentType continent, CategoryType category, TimeType time, int page, String sort) {
+	public Page<Debate> getFinishDebateRooms(String query, ContinentType continent, CategoryType category, MemberNumberType member, int page, String sort) {
 		Pageable pageable = PageRequest.of(page, 15);
-		return debateRepository.findFinishDebatesByParams(query, continent, category, time, sort, pageable);
+		return debateRepository.findFinishDebatesByParams(query, continent, category, member, sort, pageable);
 	}
 
 	/**

--- a/src/main/java/com/example/earthtalk/domain/debate/service/DebateRoomService.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/service/DebateRoomService.java
@@ -10,27 +10,27 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import com.example.earthtalk.domain.debate.entity.*;
+import com.example.earthtalk.domain.news.entity.TimeType;
+import com.example.earthtalk.global.constant.ContinentType;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import com.example.earthtalk.domain.debate.dto.CreateDebateRoomRequest;
-import com.example.earthtalk.domain.debate.dto.DebateRoomRedisDto;
 import com.example.earthtalk.domain.debate.dto.DebateRoomResponse;
 import com.example.earthtalk.domain.debate.dto.DebateUserResponse;
 import com.example.earthtalk.domain.debate.dto.VoteRequest;
 import com.example.earthtalk.domain.debate.dto.WaitRoomResponse;
-import com.example.earthtalk.domain.debate.entity.Debate;
-import com.example.earthtalk.domain.debate.entity.DebateParticipants;
-import com.example.earthtalk.domain.debate.entity.FlagType;
-import com.example.earthtalk.domain.debate.entity.RoomType;
 import com.example.earthtalk.domain.debate.repository.DebateParticipantsRepository;
 import com.example.earthtalk.domain.debate.repository.DebateRepository;
 import com.example.earthtalk.domain.debate.store.DebateRoomStore;
 import com.example.earthtalk.domain.debate.store.DebateUserStore;
-import com.example.earthtalk.domain.news.entity.MemberNumberType;
 import com.example.earthtalk.domain.news.entity.News;
 import com.example.earthtalk.domain.news.repository.NewsRepository;
 import com.example.earthtalk.domain.user.entity.User;
@@ -138,6 +138,11 @@ public class DebateRoomService {
 	public Debate getDebate(String roomId) {
 		return debateRepository.findByUuid(UUID.fromString(roomId))
 			.orElseThrow(() -> new IllegalArgumentException(ErrorCode.DEBATEROOM_NOT_FOUND.getMessage()));
+	}
+
+	public Page<Debate> getFinishDebateRooms(String query, ContinentType continent, CategoryType category, TimeType time, int page, String sort) {
+		Pageable pageable = PageRequest.of(page, 15);
+		return debateRepository.findFinishDebatesByParams(query, continent, category, time, sort, pageable);
 	}
 
 	/**


### PR DESCRIPTION
## 📄 요약 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
<!-- 이슈 닫아주세요 -->
> closed #153 

## 🙋🏻 More <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
종료된 토론방 조회에 관한 API

파라미터로 아래와 같은 값을 받습니다.
- q : 토론방 제목 - 검색어 - 미 기입 시 전체조회
- continent : 대륙 타입 - AS, AM, EU, JP, CN, AF, KR - 미 기입 시 전체조회
- category : 토론방 카테고리 - PO, EC, SO, CU, EN, SP, IT, CO, ETC - 미 기입 시 전체조회
- member : T1 - 1:1, T2 - 3:3 - 미 기입 시 전체조회
- p : page 값 - 페이지네이션 용 - 미 기입 시 1페이지
- sort : recent, popular( 인기순 - 투표숫자 ) - 미 기입 시 recent (최신순)

추가 사항
 - 제가 사용한 클래스에 대해서 import 정리
 - DebateRoomController 반환타입 ApiResponse<Object> 에서 명확하게 변경

## ✅ 피드백 반영사항 & 궁금한 점  <!-- 지난 코드리뷰에서 고친 사항 또는 궁금한 점 적어주세요 -->
