### PR TITLE
refactor: 토론방 상세 정보 조회에 유저 정보 추가

### DIFF
--- a/src/main/java/com/example/earthtalk/EarthTalkApplication.java
+++ b/src/main/java/com/example/earthtalk/EarthTalkApplication.java
@@ -2,7 +2,6 @@ package com.example.earthtalk;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 

--- a/src/main/java/com/example/earthtalk/controller/UserController.java
+++ b/src/main/java/com/example/earthtalk/controller/UserController.java
@@ -3,7 +3,6 @@ package com.example.earthtalk.controller;
 import com.example.earthtalk.domain.news.service.NewsDataService;
 import com.example.earthtalk.domain.oauth.dto.CustomOAuth2User;
 import com.example.earthtalk.domain.user.dto.response.UserBookmarksResponse;
-import com.example.earthtalk.domain.user.dto.response.UserDebateChatsResponse;
 import com.example.earthtalk.domain.user.dto.response.UserDebateDetailsResponse;
 import com.example.earthtalk.domain.user.dto.response.UserDebatesResponse;
 import com.example.earthtalk.domain.user.dto.response.UserFolloweesResponse;
@@ -21,6 +20,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -138,18 +138,17 @@ public class UserController {
     @ApiResponses(value = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공")})
     @GetMapping("/mypage/{debatesId}/debateChats")
-    public ResponseEntity<ApiResponse<List<UserDebateChatsResponse>>> getUserDebateChats(
+    public ResponseEntity<ApiResponse<Map<String, Object>>> getUserDebateChats(
         @PathVariable("debatesId") Long debatesId) throws JsonProcessingException {
         List<UserDebateDetailsResponse> responseHeader = userService.getDebateDetails( debatesId );
 
         String headerData = new ObjectMapper().writeValueAsString(responseHeader);
 
-        List<UserDebateChatsResponse> response = userService.getUserDebateChats( debatesId );
+        Map<String, Object> response = userService.getUserDebateChats( debatesId );
         return ResponseEntity.ok()
-            .header("X-Debate-Details", headerData)  // 헤더에 데이터 추가
-            .body(ApiResponse.createSuccess(response)); // 본문 데이터 설정
+            .header("X-Debate-Details", headerData)
+            .body(ApiResponse.createSuccess(response));
     }
-
 
     @Operation(summary = "사용자 팔로잉 목록 API", description = "사용자가 팔로우하고 있는 사용자 목록을 조회합니다.")
     @ApiResponses(value = {
@@ -169,7 +168,6 @@ public class UserController {
         return ResponseEntity.ok().body(ApiResponse.createSuccess(response));
     }
 
-    // 팔로워 추가
     @Operation(summary = "사용자 팔로워 추가 API", description = "사용자의 팔로워를 추가합니다.")
     @ApiResponses(value = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공")})
@@ -179,7 +177,6 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.createSuccessWithNoData());
     }
 
-    // followee 추가
     @Operation(summary = "사용자 팔로잉 추가 API", description = "팔로우하는 사용자를 추가합니다.")
     @ApiResponses(value = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공")})

--- a/src/main/java/com/example/earthtalk/domain/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/example/earthtalk/domain/user/repository/UserRepositoryImpl.java
@@ -2,7 +2,6 @@ package com.example.earthtalk.domain.user.repository;
 
 import static com.example.earthtalk.domain.debate.entity.DebateRole.OBSERVER;
 import static com.example.earthtalk.domain.debate.entity.DebateRole.PARTICIPANT;
-
 import com.example.earthtalk.domain.debate.entity.QDebate;
 import com.example.earthtalk.domain.debate.entity.QDebateChat;
 import com.example.earthtalk.domain.debate.entity.QDebateParticipants;
@@ -138,10 +137,11 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
     }
 
 
-    // 유저가 참관/참여한 토론방 상세 조회
+    // 유저가 참관/참여한 토론방 상세 조회 - body
     public List<Tuple> findAllWithDebateChats(Long debatesId) {
         QDebateChat dc = QDebateChat.debateChat;
         QDebateParticipants dp = QDebateParticipants.debateParticipants;
+        QUser user = QUser.user;
 
         List<Tuple> result = jpaQueryFactory
             .select(
@@ -149,10 +149,17 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
                 dp.role,
                 dp.position,
                 dc.content.as("debateContent"),
-                dc.createdAt.as("chatCreatedAt"))
+                dc.createdAt.as("chatCreatedAt"),
+                user.nickname,
+                user.profileUrl,
+                user.winNumber,
+                user.defeatNumber,
+                user.drawNumber
+            )
             .from(dc)
             .join(dp).on(dc.debate.id.eq(dp.debate.id)
                 .and(dc.debateParticipants.id.eq(dp.user.id)))
+            .join(user).on(dp.user.id.eq(user.id))
             .where(dc.debate.id.eq(debatesId))
             .orderBy(dc.createdAt.asc())
             .fetch();

--- a/src/main/java/com/example/earthtalk/domain/user/service/UserService.java
+++ b/src/main/java/com/example/earthtalk/domain/user/service/UserService.java
@@ -25,6 +25,7 @@ import com.example.earthtalk.domain.report.repository.ReportRepository;
 import com.example.earthtalk.domain.user.dto.response.UserBookmarksResponse;
 import com.example.earthtalk.domain.user.dto.response.UserDebateChatsResponse;
 import com.example.earthtalk.domain.user.dto.response.UserDebateDetailsResponse;
+import com.example.earthtalk.domain.user.dto.response.UserDebateRoomInfoResponse;
 import com.example.earthtalk.domain.user.dto.response.UserDebatesResponse;
 import com.example.earthtalk.domain.user.dto.response.UserFolloweesResponse;
 import com.example.earthtalk.domain.user.dto.response.UserFollowersResponse;
@@ -43,7 +44,9 @@ import com.querydsl.core.Tuple;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -211,15 +214,17 @@ public class UserService {
 
             userDebateDetailsDTOList.add(UserDebateDetailsResponse.from(debate, link));
         }
-        System.out.println(userDebateDetailsDTOList);
+
         return userDebateDetailsDTOList;
     }
 
     // 유저가 참여/참관한 토론방 상세 조회 - body
-    public List<UserDebateChatsResponse> getUserDebateChats(Long debatesId) {
+    public Map<String, Object> getUserDebateChats(Long debatesId) {
         List<Tuple> userDebateChatsData = userRepository.findAllWithDebateChats(debatesId);
 
         List<UserDebateChatsResponse> userDebateChatsDTOList = new ArrayList<>();
+        List<UserDebateRoomInfoResponse> pros = new ArrayList<>();
+        List<UserDebateRoomInfoResponse> cons = new ArrayList<>();
 
         for ( Tuple data : userDebateChatsData ) {
             Long userId = data.get(0, Long.class);
@@ -229,13 +234,30 @@ public class UserService {
                 String.valueOf(data.get(2, FlagType.class)));
             String debateContent = data.get(3, String.class);
             LocalDateTime createdAt = data.get(4, LocalDateTime.class);
-
+            String nickname = data.get(5, String.class);
+            String profileImg = data.get(6, String.class);
+            Long winNumber = data.get(7, Long.class);
+            Long defeatNumber = data.get(8, Long.class);
+            Long drawNumber = data.get(9, Long.class);
 
             userDebateChatsDTOList.add(new UserDebateChatsResponse(
                 userId, role, position, debateContent, createdAt));
+
+            UserDebateRoomInfoResponse userInfo = new UserDebateRoomInfoResponse(userId, nickname, profileImg, winNumber, defeatNumber, drawNumber);
+            if (position == FlagType.PRO) {
+                pros.add(userInfo);
+            } else if (position == FlagType.CON) {
+                cons.add(userInfo);
+            }
         }
 
-        return userDebateChatsDTOList;
+        Map<String, Object> result = new HashMap<>();
+
+        result.put("찬성", pros);
+        result.put("반대", cons);
+        result.put("chats", userDebateChatsDTOList);
+
+        return result;
     }
 
 


### PR DESCRIPTION
## 📄 요약 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
<!-- 이슈 닫아주세요 -->
> closed #141

토론방 상세 정보 조회에 유저 정보 추가(id, nickname, profileImg, 승무패 정보)

![image](https://github.com/user-attachments/assets/85674188-7306-4618-981a-30df44676196)
![image](https://github.com/user-attachments/assets/081147ba-fc90-49e5-ad11-ce267147eecd)
