### PR TITLE
feat: 10분 동안 커넥션이 없는 세션 자동 종료 기능 추가

### DIFF
--- a/src/main/java/com/example/earthtalk/domain/debate/component/SessionRegistry.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/component/SessionRegistry.java
@@ -1,0 +1,25 @@
+package com.example.earthtalk.domain.debate.component;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class SessionRegistry {
+
+	private final Map<String, WebSocketSession> sessions = new ConcurrentHashMap<>();
+
+	public void registerSession(WebSocketSession session) {
+		sessions.put(session.getId(), session);
+	}
+
+	public WebSocketSession getSession(String sessionId) {
+		return sessions.get(sessionId);
+	}
+
+	public void removeSession(String sessionId) {
+		sessions.remove(sessionId);
+	}
+}

--- a/src/main/java/com/example/earthtalk/domain/debate/component/WebSocketEventListener.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/component/WebSocketEventListener.java
@@ -46,6 +46,8 @@ public class WebSocketEventListener {
 	private final ObserverChatManagementService observerChatManagementService;
 	private final ObserverUserService observerUserService;
 
+	private final WebSocketIdleSessionMonitor webSocketIdleSessionMonitor;
+
 	// 여러 개의 맵 대신 세션 ID와 관련된 정보를 하나의 객체(SessionInfo)로 관리
 	private final Map<String, SessionInfo> sessionInfoMap = new ConcurrentHashMap<>();
 
@@ -65,12 +67,13 @@ public class WebSocketEventListener {
 	public void handleWebSocketConnectListener(SessionConnectedEvent event) {
 		log.info("새로운 WebSocket 연결 수신: sessionId={}", StompHeaderAccessor.wrap(event.getMessage()).getSessionId());
 		StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+		String sessionId = headerAccessor.getSessionId();
+		webSocketIdleSessionMonitor.registerSession(sessionId);
 		String destination = headerAccessor.getDestination();
 		if (destination != null && !destination.startsWith("/room-list")) {
 			String roomId = (String)headerAccessor.getSessionAttributes().get("roomId");
 			String userName = (String)headerAccessor.getSessionAttributes().get("userName");
 			if (destination.startsWith("/topic/debate/")) {
-				String sessionId = headerAccessor.getSessionId();
 				String position = (String)headerAccessor.getSessionAttributes().get("position");
 				if (roomId != null && userName != null && position != null) {
 					Debate debate = debateRoomService.getDebateRoom(roomId);
@@ -88,7 +91,6 @@ public class WebSocketEventListener {
 					}
 				}
 			} else if (destination.startsWith("/topic/observer/")) {
-				String sessionId = headerAccessor.getSessionId();
 				if (roomId != null && userName != null) {
 					observerSessionMap.put(sessionId, roomId);
 					observerUserService.addUser(roomId, userName);
@@ -153,6 +155,8 @@ public class WebSocketEventListener {
 				observerUserService.removeUser(observerRoomId, userNameAttr);
 			}
 		}
+
+		webSocketIdleSessionMonitor.unregisterSession(sessionId);
 
 	}
 }

--- a/src/main/java/com/example/earthtalk/domain/debate/component/WebSocketIdleSessionMonitor.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/component/WebSocketIdleSessionMonitor.java
@@ -1,0 +1,67 @@
+package com.example.earthtalk.domain.debate.component;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.example.earthtalk.global.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class WebSocketIdleSessionMonitor {
+
+	private static final long IDLE_TIMEOUT = 10 * 60 * 1000;
+
+	private final Map<String, Long> sessionActivityMap = new ConcurrentHashMap<>();
+
+	private final SessionRegistry sessionRegistry;
+
+	public void registerSession(String sessionId) {
+		sessionActivityMap.put(sessionId, System.currentTimeMillis());
+	}
+
+	public void updateSessionActivity(String sessionId) {
+		sessionActivityMap.put(sessionId, System.currentTimeMillis());
+	}
+
+	public void unregisterSession(String sessionId) {
+		sessionActivityMap.remove(sessionId);
+
+		sessionRegistry.removeSession(sessionId);
+	}
+
+	@Scheduled(fixedRate = 60000)
+	public void checkIdleSessions() {
+		long now = System.currentTimeMillis();
+		for (Map.Entry<String, Long> entry : sessionActivityMap.entrySet()) {
+			if (now - entry.getValue() > IDLE_TIMEOUT) {
+				String sessionId = entry.getKey();
+				closeSession(sessionId);
+				sessionActivityMap.remove(sessionId);
+			}
+		}
+	}
+
+	private void closeSession(String sessionId) {
+		WebSocketSession session = sessionRegistry.getSession(sessionId);
+		if (session != null && session.isOpen()) {
+			try {
+				session.close();
+			} catch (Exception e) {
+				throw new RuntimeException(ErrorCode.SESSION_DISCONNECT_FAILED.getMessage());
+			}
+		}
+		sessionRegistry.removeSession(sessionId);
+		log.info("10분 동안 활동이 없어 종료하는 세션: {}", sessionId);
+	}
+}

--- a/src/main/java/com/example/earthtalk/domain/debate/controller/ChatController.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/controller/ChatController.java
@@ -7,12 +7,14 @@ import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.stereotype.Controller;
 
+import com.example.earthtalk.domain.debate.component.WebSocketIdleSessionMonitor;
 import com.example.earthtalk.domain.debate.store.DebateMessageStore;
 import com.example.earthtalk.domain.debate.dto.DebateMessage;
 import com.example.earthtalk.domain.debate.dto.ObserverMessage;
 import com.example.earthtalk.domain.debate.store.ObserverMessageStore;
 import com.example.earthtalk.global.exception.ErrorCode;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -23,16 +25,13 @@ import lombok.extern.slf4j.Slf4j;
  * </p>
  */
 @Controller
+@RequiredArgsConstructor
 @Slf4j
 public class ChatController {
 
 	private final DebateMessageStore debateMessageStore;
 	private final ObserverMessageStore observerMessageStore;
-
-	public ChatController(DebateMessageStore debateMessageStore, ObserverMessageStore observerMessageStore) {
-		this.debateMessageStore = debateMessageStore;
-		this.observerMessageStore = observerMessageStore;
-	}
+	private final WebSocketIdleSessionMonitor webSocketIdleSessionMonitor;
 
 	/**
 	 * 토론 메시지를 처리하여 검증된 DebateMessage를 브로드캐스트합니다.
@@ -53,6 +52,9 @@ public class ChatController {
 		@Payload DebateMessage message,
 		SimpMessageHeaderAccessor headerAccessor
 	) {
+
+		String sessionId = headerAccessor.getSessionId();
+		webSocketIdleSessionMonitor.updateSessionActivity(sessionId);
 		log.info("new debate message : {}", message.getMessage());
 
 		if (!message.isValidMessage()) {
@@ -80,7 +82,12 @@ public class ChatController {
 	 */
 	@MessageMapping("/observer/{roomId}")
 	@SendTo("/topic/observer/{roomId}")
-	public ObserverMessage sendObserverMessage(@DestinationVariable String roomId, @Payload ObserverMessage message) {
+	public ObserverMessage sendObserverMessage(@DestinationVariable String roomId, @Payload ObserverMessage message,
+		SimpMessageHeaderAccessor headerAccessor
+	) {
+
+		String sessionId = headerAccessor.getSessionId();
+		webSocketIdleSessionMonitor.updateSessionActivity(sessionId);
 		if (message.getEvent() == null || message.getEvent().trim().isEmpty() ||
 		message.getUserName() == null || message.getUserName().trim().isEmpty() ||
 		message.getMessage() == null || message.getMessage().trim().isEmpty()) {

--- a/src/main/java/com/example/earthtalk/domain/debate/controller/FilteredUpdateController.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/controller/FilteredUpdateController.java
@@ -9,6 +9,7 @@ import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.stereotype.Controller;
 
+import com.example.earthtalk.domain.debate.component.WebSocketIdleSessionMonitor;
 import com.example.earthtalk.domain.debate.dto.DebateMetaDataResponse;
 import com.example.earthtalk.domain.debate.dto.RoomStatusUpdate;
 import com.example.earthtalk.domain.debate.entity.CategoryType;
@@ -24,9 +25,14 @@ public class FilteredUpdateController {
 
 	private final DebateMetaDataService debateMetaDataService;
 
+	private final WebSocketIdleSessionMonitor webSocketIdleSessionMonitor;
+
 	@MessageMapping("/filteredUpdate")
 	@SendTo("/topic/filteredStatus")
 	public RoomStatusUpdate sendRoomStatusUpdate(SimpMessageHeaderAccessor headerAccessor) {
+		String sessionId = headerAccessor.getSessionId();
+		webSocketIdleSessionMonitor.updateSessionActivity(sessionId);
+
 		ContinentType continentType = (ContinentType) headerAccessor.getSessionAttributes().get("continentType");
 		CategoryType categoryType = (CategoryType) headerAccessor.getSessionAttributes().get("categoryType");
 		MemberNumberType memberNumberType = (MemberNumberType) headerAccessor.getSessionAttributes().get("memberNumberType");

--- a/src/main/java/com/example/earthtalk/domain/debate/controller/RealTimeUpdateController.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/controller/RealTimeUpdateController.java
@@ -2,8 +2,10 @@ package com.example.earthtalk.domain.debate.controller;
 
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.stereotype.Controller;
 
+import com.example.earthtalk.domain.debate.component.WebSocketIdleSessionMonitor;
 import com.example.earthtalk.domain.debate.dto.RoomStatusUpdate;
 import com.example.earthtalk.domain.debate.service.DebateMetaDataService;
 
@@ -14,10 +16,14 @@ import lombok.RequiredArgsConstructor;
 public class RealTimeUpdateController {
 
 	private final DebateMetaDataService debateMetaDataService;
+	private final WebSocketIdleSessionMonitor webSocketIdleSessionMonitor;
 
 	@MessageMapping("/updateStatus")
 	@SendTo("/topic/roomStatus")
-	public RoomStatusUpdate sendRoomStatusUpdate() {
+	public RoomStatusUpdate sendRoomStatusUpdate(SimpMessageHeaderAccessor headerAccessor) {
+		String sessionId = headerAccessor.getSessionId();
+		webSocketIdleSessionMonitor.updateSessionActivity(sessionId);
+
 		return RoomStatusUpdate.builder()
 			.roomCount(debateMetaDataService.getSortByCurrentCount().size())
 			.roomSortedByCreatedAt(debateMetaDataService.getSortByTime())

--- a/src/main/java/com/example/earthtalk/domain/debate/entity/Debate.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/entity/Debate.java
@@ -73,6 +73,7 @@ public class Debate extends BaseTimeEntity {
 
     private LocalDateTime endTime;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private RoomType status;
 

--- a/src/main/java/com/example/earthtalk/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/earthtalk/global/exception/ErrorCode.java
@@ -43,6 +43,7 @@ public enum ErrorCode { // 예외 발생시, body에 실어 날려줄 상태, co
     DEBATE_NO_PARTICIPANTS(400, -5003, "토론방에 인원이 없습니다."),
     SAVE_FAILED(500, -5004, "토론방 저장에 실패했습니다."),
     CHAT_NOT_FOUND(404, -5004, "조회된 채팅이 존재하지 않습니다."),
+    SESSION_DISCONNECT_FAILED(500, -5005, "세션 연결 해제에 실패했습니다."),
 
     //-6000 OAUTH
     OAUTH_NOT_FOUND(404, -6000, "소셜로그인 계정 정보가 존재하지 않습니다."),


### PR DESCRIPTION
## 📄 요약 
10분 동안 커넥션이 없는 세션 자동 종료 기능 추가
<!-- 이슈 닫아주세요 -->
> closed #162 

- WebSocketIdleSessionMonitor에서 10분 이상 활동이 없는 세션을 감지하여 자동 종료 처리
- 종료된 세션은 SessionRegistry에서 제거하여 리소스 누수 방지
- 관련 로그 출력 및 예외 처리 로직 추가

## ✅ 피드백 반영사항 & 궁금한 점  <!-- 지난 코드리뷰에서 고친 사항 또는 궁금한 점 적어주세요 -->
