### PR TITLE
fix: 종료된 토론방 조회 등 API 수정

### DIFF
--- a/src/main/java/com/example/earthtalk/domain/debate/controller/DebateRoomController.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/controller/DebateRoomController.java
@@ -1,20 +1,12 @@
 package com.example.earthtalk.domain.debate.controller;
 
 import com.example.earthtalk.domain.debate.store.VoteStore;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 
 import com.example.earthtalk.domain.debate.entity.*;
 import com.example.earthtalk.domain.news.entity.MemberNumberType;
-import com.example.earthtalk.domain.news.entity.TimeType;
 import com.example.earthtalk.global.constant.ContinentType;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -29,18 +21,8 @@ import com.example.earthtalk.domain.debate.dto.VoteRequest;
 import com.example.earthtalk.domain.debate.dto.VoteResponse;
 import com.example.earthtalk.domain.debate.dto.WaitRoomResponse;
 import com.example.earthtalk.domain.debate.entity.Debate;
-import com.example.earthtalk.domain.debate.entity.DebateParticipants;
-import com.example.earthtalk.domain.debate.entity.FlagType;
-import com.example.earthtalk.domain.debate.entity.RoomType;
-import com.example.earthtalk.domain.debate.repository.DebateParticipantsRepository;
 import com.example.earthtalk.domain.debate.repository.DebateRepository;
 import com.example.earthtalk.domain.debate.service.DebateRoomService;
-import com.example.earthtalk.domain.debate.service.DebateUserService;
-import com.example.earthtalk.domain.debate.store.DebateUserStore;
-import com.example.earthtalk.domain.report.dto.request.InsertReportRequest;
-import com.example.earthtalk.domain.report.service.ReportService;
-import com.example.earthtalk.domain.user.entity.User;
-import com.example.earthtalk.domain.user.repository.UserRepository;
 import com.example.earthtalk.global.exception.ErrorCode;
 import com.example.earthtalk.global.response.ApiResponse;
 
@@ -57,8 +39,6 @@ public class DebateRoomController {
 
 	private final DebateRepository debateRepository;
 	private final DebateRoomService debateRoomService;
-	private final DebateUserService debateUserService;
-	private final DebateUserStore debateUserStore;
 	private final VoteStore voteStore;
 
 	@Operation(summary = "토론방 상세 조회 API", description = "토론방의 UUID로 상세 정보를 조회합니다.")
@@ -78,8 +58,9 @@ public class DebateRoomController {
 		return ResponseEntity.ok().body(ApiResponse.createSuccess(response));
 	}
 
+	@Operation(summary = "종료된 토론방 리스트 조회 API", description = "status 가 closed 에 대한 토론방의 리스트를 조회합니다.")
 	@GetMapping("/debateRoom/finished")
-	public ResponseEntity<ApiResponse<Page<Debate>>> getFinishedDebateRoom(
+	public ResponseEntity<ApiResponse<Page<DebateRoomResponse>>> getFinishedDebateRoom(
 			@RequestParam(value = "q", required = false) String q,
 			@RequestParam(value = "continent", required = false) ContinentType continent,
 			@RequestParam(value = "category", required = false)CategoryType category,
@@ -88,7 +69,7 @@ public class DebateRoomController {
 			@RequestParam(value = "sort", required = false, defaultValue = "recent") String sort
 	) {
 		page = page <= 1 ? 0 : page - 1;
-		Page<Debate> debates = debateRoomService.getFinishDebateRooms(q, continent, category, member, page, sort);
+		Page<DebateRoomResponse> debates = debateRoomService.getFinishDebateRooms(q, continent, category, member, page, sort);
 		return ResponseEntity.ok(ApiResponse.createSuccess(debates));
 	}
 
@@ -135,12 +116,12 @@ public class DebateRoomController {
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 데이터입니다."),
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 토론방을 찾을 수 없습니다."),
 	})
-	@PutMapping("/vote/{roomId}")
-	public ResponseEntity<ApiResponse<Object>> putVote(
-		@PathVariable("roomId") String roomId,
+	@PutMapping("/vote/{uuid}")
+	public ResponseEntity<ApiResponse<Void>> putVote(
+		@PathVariable("uuid") String uuid,
 		@RequestBody VoteRequest request) {
-		voteStore.processVote(UUID.fromString(roomId), request);
-		return ResponseEntity.ok(ApiResponse.createSuccessWithNoData());
+		voteStore.processVote(UUID.fromString(uuid), request);
+		return ResponseEntity.ok(ApiResponse.createSuccess(null));
 	}
 
 	@Operation(summary = "투표 조회 API", description = "토론방의 현재 투표 수(찬성, 반대, 중립)를 조회합니다.")
@@ -148,11 +129,11 @@ public class DebateRoomController {
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "투표 수가 성공적으로 조회되었습니다."),
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 토론방을 찾을 수 없습니다."),
 	})
-	@GetMapping("/vote/{roomId}")
+	@GetMapping("/vote/{uuid}")
 	public ResponseEntity<ApiResponse<VoteResponse>> getVote(
-		@PathVariable("roomId") Long roomId
+		@PathVariable("uuid") String uuid
 	) {
-		Debate debate = debateRepository.findById(roomId)
+		Debate debate = debateRepository.findByUuid(UUID.fromString(uuid))
 			.orElseThrow(() -> new IllegalArgumentException(ErrorCode.DEBATEROOM_NOT_FOUND.getMessage()));
 
 		VoteResponse response = VoteResponse.builder()
@@ -163,7 +144,4 @@ public class DebateRoomController {
 
 		return ResponseEntity.ok(ApiResponse.createSuccess(response));
 	}
-
-
-
 }

--- a/src/main/java/com/example/earthtalk/domain/debate/dto/DebateRoomResponse.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/dto/DebateRoomResponse.java
@@ -26,5 +26,6 @@ public class DebateRoomResponse {
 	private final RoomType status;
 	private final int timeType;
 	private final int speakCountType;
+	private final boolean resultEnabled;
 	private final List<DebateUserResponse> participants;
 }

--- a/src/main/java/com/example/earthtalk/domain/debate/dto/ObserverMessage.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/dto/ObserverMessage.java
@@ -3,10 +3,10 @@ package com.example.earthtalk.domain.debate.dto;
 import java.time.LocalDateTime;
 
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Data
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class ObserverMessage {

--- a/src/main/java/com/example/earthtalk/domain/debate/service/DebateRoomService.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/service/DebateRoomService.java
@@ -5,22 +5,20 @@ import com.example.earthtalk.domain.debate.entity.VoteStatus;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.time.LocalDateTime;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import com.example.earthtalk.domain.debate.entity.*;
 import com.example.earthtalk.domain.news.entity.MemberNumberType;
 import com.example.earthtalk.domain.news.entity.TimeType;
 import com.example.earthtalk.global.constant.ContinentType;
+import com.example.earthtalk.global.exception.NotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -140,9 +138,17 @@ public class DebateRoomService {
 			.orElseThrow(() -> new IllegalArgumentException(ErrorCode.DEBATEROOM_NOT_FOUND.getMessage()));
 	}
 
-	public Page<Debate> getFinishDebateRooms(String query, ContinentType continent, CategoryType category, MemberNumberType member, int page, String sort) {
+	public Page<DebateRoomResponse> getFinishDebateRooms(String query, ContinentType continent, CategoryType category, MemberNumberType member, int page, String sort) {
 		Pageable pageable = PageRequest.of(page, 15);
-		return debateRepository.findFinishDebatesByParams(query, continent, category, member, sort, pageable);
+		Page<Debate> debatePage = debateRepository.findFinishDebatesByParams(query, continent, category, member, sort, pageable);
+		List<DebateRoomResponse> responses = new ArrayList<>();
+		for(Debate debate : debatePage.getContent()) {
+			if (debate == null) {
+				throw new NotFoundException(ErrorCode.DEBATEROOM_NOT_FOUND);
+			}
+			responses.add(buildDebateRoomResponse(debate, debate.getUuid(), true));
+		}
+		return new PageImpl<>(responses, pageable, debatePage.getTotalElements());
 	}
 
 	/**
@@ -244,7 +250,8 @@ public class DebateRoomService {
 			.newsUrl(debate.getNews() != null ? debate.getNews().getLink() : null)
 			.status(debate.getStatus())
 			.timeType(debate.getTime().getValue())
-			.speakCountType(debate.getSpeakCount().getValue());
+			.speakCountType(debate.getSpeakCount().getValue())
+			.resultEnabled(debate.isResultEnabled());
 
 		if (includeParticipants) {
 			List<DebateUserResponse> participants = debateParticipantsRepository.findByDebate_Uuid(roomId)


### PR DESCRIPTION
## 📄 요약 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
<!-- 이슈 닫아주세요 -->
> closed #198 

## 🙋🏻 More <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
1. 종료된 토론방 조회 API 수정
2. 투표 관련 API 파라미터 uuid 로 변경
3. DebateRoomResponse 에 필드 값 resultEnabled 추가

## ✅ 피드백 반영사항 & 궁금한 점  <!-- 지난 코드리뷰에서 고친 사항 또는 궁금한 점 적어주세요 -->
