### PR TITLE
feat: 토론도중 참여한 관전자에게 턴 정보를 보내는 API 구현

### DIFF
--- a/src/main/java/com/example/earthtalk/domain/debate/controller/DebateRoomController.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/controller/DebateRoomController.java
@@ -1,6 +1,10 @@
 package com.example.earthtalk.domain.debate.controller;
 
+import com.example.earthtalk.domain.debate.dto.TurnInfoResponse;
+import com.example.earthtalk.domain.debate.service.DebateTurnManagementService;
 import com.example.earthtalk.domain.debate.store.VoteStore;
+import com.example.earthtalk.domain.news.entity.TimeType;
+import com.example.earthtalk.global.exception.NotFoundException;
 import java.util.UUID;
 
 import com.example.earthtalk.domain.debate.entity.*;
@@ -41,6 +45,7 @@ public class DebateRoomController {
 
 	private final DebateRepository debateRepository;
 	private final DebateRoomService debateRoomService;
+	private final DebateTurnManagementService debateTurnManagementService;
 	private final VoteStore voteStore;
 
 	@Operation(summary = "토론방 상세 조회 API", description = "토론방의 UUID로 상세 정보를 조회합니다.")
@@ -146,6 +151,19 @@ public class DebateRoomController {
 			.neutralNumber(debate.getNeutralNumber())
 			.build();
 
+		return ResponseEntity.ok(ApiResponse.createSuccess(response));
+	}
+
+	@Operation(summary = "토론 턴 조회 API", description = "토론방 중간에 입장한 관전자가 현재 턴 카운트와 남은시간을 조회할 수 있습니다.")
+	@ApiResponses(value = {
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 토론방을 찾을 수 없습니다."),
+	})
+	@GetMapping("/turn/{uuid}")
+	public ResponseEntity<ApiResponse<TurnInfoResponse>> getCurrentTurn(@PathVariable String uuid){
+		TimeType timeType = debateRepository.findByUuid(UUID.fromString(uuid))
+			.orElseThrow(()->new NotFoundException(ErrorCode.DEBATEROOM_NOT_FOUND)).getTime();
+		TurnInfoResponse response = debateTurnManagementService.getCurrentTurn(UUID.fromString(uuid), timeType);
 		return ResponseEntity.ok(ApiResponse.createSuccess(response));
 	}
 }

--- a/src/main/java/com/example/earthtalk/domain/debate/dto/TurnInfoResponse.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/dto/TurnInfoResponse.java
@@ -1,0 +1,13 @@
+package com.example.earthtalk.domain.debate.dto;
+
+import com.example.earthtalk.domain.debate.entity.FlagType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class TurnInfoResponse {
+    private FlagType flagType;
+    private Integer turnCount;
+
+}

--- a/src/main/java/com/example/earthtalk/domain/debate/service/DebateTimerService.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/service/DebateTimerService.java
@@ -48,7 +48,7 @@ public class DebateTimerService {
             "message", "잠시 후 토론이 시작됩니다... "
         );
         messagingTemplate.convertAndSend("/topic/debate/" + roomId.toString(), message);
-        debateTurnManagementService.createDebateTurn(roomId,timeType);
+        debateTurnManagementService.createDebateTurn(roomId,timeType, speakCountType);
         System.out.println("Debate started for " + roomId);
     }
 

--- a/src/main/java/com/example/earthtalk/domain/debate/service/DebateTurnManagementService.java
+++ b/src/main/java/com/example/earthtalk/domain/debate/service/DebateTurnManagementService.java
@@ -1,5 +1,6 @@
 package com.example.earthtalk.domain.debate.service;
 
+import com.example.earthtalk.domain.debate.dto.TurnInfoResponse;
 import com.example.earthtalk.domain.debate.entity.EventType;
 import com.example.earthtalk.domain.debate.entity.FlagType;
 import com.example.earthtalk.domain.debate.entity.RoomType;
@@ -22,11 +23,13 @@ public class DebateTurnManagementService {
 
     private final Map<UUID, ScheduledFuture<?>> turnScheduler = new ConcurrentHashMap<>();
     private final Map<UUID, FlagType> debateTurns = new ConcurrentHashMap<>();
+    private final Map<UUID, Integer> turnCounts = new ConcurrentHashMap<>();
     private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(50);
     private final SimpMessagingTemplate messagingTemplate;
 
-    public void createDebateTurn(UUID roomId, TimeType timeType) {
+    public void createDebateTurn(UUID roomId, TimeType timeType, SpeakCountType speakCountType) {
         debateTurns.put(roomId, FlagType.NO_POSITION);
+        turnCounts.put(roomId, speakCountType.getValue());
         scheduler.schedule(()-> {
             Map<String, Object> message = Map.of(
                 "event", EventType.STATUS,
@@ -47,13 +50,14 @@ public class DebateTurnManagementService {
             debateTurns.put(roomId, FlagType.PRO);
             System.out.println("Debate Started for " + roomId);
         }
-
         Map<String, Object> message1 = Map.of(
             "event", EventType.NOTIFICATION,
-            "message", "10초 후 턴이 바뀝니다..."
+            "message", "10초 후 발언이 종료됩니다."
         );
         messagingTemplate.convertAndSend("/topic/debate/" + roomId.toString(), message1);
         System.out.println("10 Seconds to change turn.... for " + roomId);
+
+        if(turnCounts.get(roomId) <= 1) return;
 
         FlagType currentTurn = debateTurns.get(roomId);
         FlagType nextTurn = switch (currentTurn) {
@@ -63,6 +67,7 @@ public class DebateTurnManagementService {
         };
         String turn = nextTurn == FlagType.PRO ? "찬성" : "반대";
         scheduler.schedule(() -> {
+            turnCounts.put(roomId, turnCounts.get(roomId) - 1);
             Map<String, Object> message2 = Map.of(
                 "event", EventType.TURN,
                 "turn", nextTurn,
@@ -82,6 +87,19 @@ public class DebateTurnManagementService {
         }
         System.out.println("Remove debate turn for " + roomId);
 
+    }
+
+    public TurnInfoResponse getCurrentTurn(UUID roomId, TimeType timeType) {
+        int delay = (int) turnScheduler.get(roomId).getDelay(TimeUnit.SECONDS);
+
+        if( delay >= timeType.getValue() - 10 && delay <= timeType.getValue() ) {
+            delay = delay - timeType.getValue() - 10;
+        }
+
+        return TurnInfoResponse.builder()
+            .flagType(debateTurns.get(roomId))
+            .turnCount(delay -1)
+            .build();
     }
 
 }


### PR DESCRIPTION
## 📄 요약 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
<!-- 이슈 닫아주세요 -->
> closed #260 
토론 진행중에 관전자가 참여할 경우 턴 카운트가 얼마인지, 몇초남았는지 알 수 없던 문제를 해결하기 위해 턴정보를 리턴하는 API를 개발했습니다.

## 🙋🏻 More <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

## ✅ 피드백 반영사항 & 궁금한 점  <!-- 지난 코드리뷰에서 고친 사항 또는 궁금한 점 적어주세요 -->
