### PR TITLE
fix: 뉴스 리스트에서 좋아요 / 북마크 갯수가 제대로 전달되지 않던 오류를 수정

### DIFF
--- a/src/main/java/com/example/earthtalk/domain/news/repository/NewsFilterRepositoryImpl.java
+++ b/src/main/java/com/example/earthtalk/domain/news/repository/NewsFilterRepositoryImpl.java
@@ -33,7 +33,7 @@ public class NewsFilterRepositoryImpl implements NewsFilterRepository {
 
         List<NewsListResponse> newsList = jpaQueryFactory
             .select(Projections.constructor(NewsListResponse.class,
-                news, like.count(), bookmark.count()))
+                news, like.id.countDistinct(), bookmark.id.countDistinct()))
             .from(news)
             .leftJoin(like).on(news.id.eq(like.news.id))
             .leftJoin(bookmark).on(news.id.eq(bookmark.news.id))
@@ -55,7 +55,7 @@ public class NewsFilterRepositoryImpl implements NewsFilterRepository {
         QLike like = QLike.like;
         return jpaQueryFactory
             .select(Projections.constructor(NewsListResponse.class,
-                news, like.count(), bookmark.count()))
+                news, like.id.countDistinct(), bookmark.id.countDistinct()))
             .from(news)
             .leftJoin(like).on(news.id.eq(like.news.id))
             .leftJoin(bookmark).on(news.id.eq(bookmark.news.id))


### PR DESCRIPTION
## 📄 요약 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
<!-- 이슈 닫아주세요 -->
> closed #387 
뉴스 리스트에서 좋아요,북마크 갯수가 정상출력 되지 않던 오류를 수정

## 🙋🏻 More <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 행의 갯수가 아닌 중복 제거한 id 의 갯수를 읽어오도록 변경

## ✅ 피드백 반영사항 & 궁금한 점  <!-- 지난 코드리뷰에서 고친 사항 또는 궁금한 점 적어주세요 -->
